### PR TITLE
[i30] - port over rake tasks from LV

### DIFF
--- a/lib/tasks/set_child_works.rake
+++ b/lib/tasks/set_child_works.rake
@@ -1,30 +1,24 @@
 # frozen_string_literal: true
 
-namespace :hyku do
+namespace :iiif_print do
   namespace :update do
     desc 'Make sure all child work models have the correct attribute'
     task is_child_attribute: [:environment] do
-      if defined? Account # is this a hyku app?
-        Account.find_each do |account|
-          switch!(account.cname)
+      Account.find_each do |account|
+        begin
+          switch!(account.cname) if defined? Account
           puts "********************** switched to #{account.cname} **********************"
-          touch_records
+          Hyrax.config.curation_concerns.each do |cc|
+            puts "********************** checking #{cc}s **********************"
+            next if cc.count.zero?
+
+            cc.find_each(&:save)
+          end
+        rescue StandardError
+          puts "********************** failed to update account #{account.cname} **********************"
+          next
         end
-      else # this must be a hyrax app
-        touch_records
       end
-      puts "********************** DONE! **********************"
-    end
-
-    def touch_records
-      Hyrax.config.curation_concerns.each do |cc|
-        puts "********************** checking #{cc}s **********************"
-        next if cc.count.zero?
-
-        cc.find_each(&:save)
-      end
-    rescue StandardError => e
-      puts "********************** #{e} **********************"
     end
   end
 end

--- a/lib/tasks/set_parent_thumbnail.rake
+++ b/lib/tasks/set_parent_thumbnail.rake
@@ -21,7 +21,6 @@ namespace :iiif_print do
               work.representative = child_work.file_sets.first if work.representative_id.blank?
               work.thumbnail = child_work.file_sets.first if work.thumbnail_id.blank?
               pdf = child_work.file_sets.select { |f| f.label.match(/.pdf/) }.first
-              byebug
               work.update_attributes!(rendering_ids: [pdf.id]) if pdf.present?
               work.save
             end

--- a/lib/tasks/set_parent_thumbnail.rake
+++ b/lib/tasks/set_parent_thumbnail.rake
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+namespace :iiif_print do
+  namespace :update do
+    desc 'Make sure all works have a thumbnail'
+    task set_parent_thumbnail: [:environment] do
+      Account.find_each do |account|
+        begin
+          switch!(account.cname) if defined? Account
+          puts "********************** switched to #{account.cname} **********************"
+          Hyrax.config.curation_concerns.each do |cc|
+            next if cc.count.zero?
+
+            puts "********************** checking #{cc}s **********************"
+            cc.find_each do |work|
+              # the representative thumbnail for the parent should be the first page sorted alphanumerically by source_identifier
+              sorted_children = work.child_works&.sort_by { |child_work| child_work.identifier.first }
+              child_work = sorted_children.first
+              next if work.thumbnail || child_work.blank?
+
+              work.representative = child_work.file_sets.first if work.representative_id.blank?
+              work.thumbnail = child_work.file_sets.first if work.thumbnail_id.blank?
+              pdf = child_work.file_sets.select { |f| f.label.match(/.pdf/) }.first
+              byebug
+              work.update_attributes!(rendering_ids: [pdf.id]) if pdf.present?
+              work.save
+            end
+            puts "********************** updated #{cc}s **********************"
+          end
+        rescue StandardError => e
+          puts "********************** error: #{e} **********************"
+          next
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary
- [ ] made adjustments to the set_child_works rake task. It was previously copied over in an earlier PR.
- [ ] ported over the set_parent_thumbnail rake task from LV 

## Acceptance Criteria 
If a parent doesn't have a thumbnail, running this rake task will set its thumbnail to be its child's first file_set (currently ordered by source identifier, as that was the requirement set in LV). This may change later. 

This rake task was originally created as a backup fix, for when the SetParentThumbnailJob doesn't complete for whatever reason. 

command: `rake iiif_print:update:set_parent_thumbnail`
## Screenshots

### BEFORE
![image](https://user-images.githubusercontent.com/10081604/209024051-4bdce030-2734-445d-a820-aea6c8e90b32.png)
 ### AFTER
![image](https://user-images.githubusercontent.com/10081604/209023695-e208baad-ce00-4cb6-a96f-1703c0c75460.png)
