### PR TITLE
add download attribute to download link

### DIFF
--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -34,7 +34,7 @@
     </li>
     <% IiifPrint::Data::WorkDerivatives.new(file_set.id).keys.each do |name| %>
       <li role="menuitem" tabindex="-1">
-        <a href="<%= "/downloads/#{file_set.id}?locale=en&file=#{name}" %>">
+        <a href="<%= "/downloads/#{file_set.id}?locale=en&file=#{name}" %>" download>
           Download <em>(as <%= name %>)</em>
         </a>
       </li>


### PR DESCRIPTION
## Prior to this commit
When a user clicks to download a derivative, the file gets opened up in the browser which renders ridiculousness.  To download, a user would have to right click and save as.

## With this commit
The user can just click the download link and expect the file to download.