### PR TITLE
update spec helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -184,6 +184,9 @@ RSpec.configure do |config|
     ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
     ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
   end
+  config.after(:suite) do # or :each or :all
+    FileUtils.rm_rf(Dir[Rails.root.join('tmp', 'derivatives', '*')])
+  end
 
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
to remove tmp derivatives after each run

## Prior to this commit
the internal test application's tmp derivatives folder would fill out with files that potentially conflicted with future tests and made them flaky

## With this commit
the tmp derivatives folder is cleared out after test suites are ran