### PR TITLE
update to actions version iiif-6

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -22,6 +22,7 @@ jobs:
       platforms: "linux/amd64"
       target: hyku-base
       worker: false
+      db: false
   test:
     needs: build
     uses: scientist-softserv/actions/.github/workflows/test.yaml@iiif-v6

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -22,7 +22,6 @@ jobs:
       platforms: "linux/amd64"
       target: hyku-base
       worker: false
-      db: false
   test:
     needs: build
     uses: scientist-softserv/actions/.github/workflows/test.yaml@iiif-v6

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.6
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@iiif-v6
     secrets: inherit
     with:
       platforms: "linux/amd64"
@@ -24,7 +24,7 @@ jobs:
       worker: false
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.6
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@iiif-v6
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.6
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@iiif-v6

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -26,6 +26,10 @@ jobs:
   test:
     needs: build
     uses: scientist-softserv/actions/.github/workflows/test.yaml@iiif-v6
+    with: 
+      db: false
   lint:
     needs: build
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@iiif-v6
+    with: 
+      db: false

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -1,4 +1,4 @@
-name: "Build Test Lint"
+name: "Build Lint Test"
 on:
   push:
     branches:
@@ -16,14 +16,15 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v3plus5
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.6
     secrets: inherit
     with:
       platforms: "linux/amd64"
       target: hyku-base
+      worker: false
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@iiif-v3plus5
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.6
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@iiif-v3plus5
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.6

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -26,10 +26,6 @@ jobs:
   test:
     needs: build
     uses: scientist-softserv/actions/.github/workflows/test.yaml@iiif-v6
-    with: 
-      db: false
   lint:
     needs: build
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@iiif-v6
-    with: 
-      db: false


### PR DESCRIPTION
this PR updates the action repo version to iiif-v6 and sets the worker and db value to false, since they don't exist in this gem