### PR TITLE
add IiifManifestPresenterDecorator generator

### DIFF
--- a/lib/generators/iiif_print/install_generator.rb
+++ b/lib/generators/iiif_print/install_generator.rb
@@ -89,11 +89,6 @@ module IiifPrint
       copy_file 'faceted_attribute_renderer_decorator.rb', 'app/renderers/hyrax/renderers/faceted_attribute_renderer_decorator.rb'
     end
 
-    def add_create_relationships_job_decorator
-      # supports setting default parent thumbnail to the first child's thumbnail, if one doesn't exist
-      copy_file 'create_relationships_job_decorator.rb', 'app/jobs/bulkrax/create_relationships_job_decorator.rb'
-    end
-
     def gather_work_types
       # check if this is a hyku application
       switch!(Account.first) if defined? Account


### PR DESCRIPTION
ref #35 

- add generator command to modify `IiifManifestPresenterDecorator` from Hyku
- resulting file after the generator should look like:

`app/presenters/hyrax/iiif_manifest_presenter_decorator.rb`
```rb
# frozen_string_literal: true

module Hyrax
  module IiifManifestPresenterDecorator
    def search_service
      url = Rails.application.routes.url_helpers.solr_document_iiif_search_url(id, host: hostname)
      Site.account.ssl_configured ? url.sub(/\Ahttp:/, 'https:') : url
    end

    ##
    # @return [String] the URL where the manifest can be found
    def manifest_url
      return '' if id.blank?

      url_helper = Rails.application.routes.url_helpers
      if hyku?
        protocol = Site.account.ssl_configured ? 'https' : 'http'
        url_helper.polymorphic_url([:manifest, model], host: hostname, protocol: protocol)
      else
        url_helper.polymorphic_url([:manifest, model], host: hostname)
      end
    end

    def hyku?
      Object.const_defined?(:Site)
    end

    def sequence_rendering
      Array(try(:rendering_ids)).map do |file_set_id|
        rendering = file_set_presenters.find { |p| p.id == file_set_id }
        next unless rendering

        { '@id' => Hyrax::Engine.routes.url_helpers.download_url(rendering.id, host: hostname),
          'format' => rendering.mime_type.presence || I18n.t("hyrax.manifest.unknown_mime_text"),
          'label' => I18n.t("hyrax.manifest.download_text") + (rendering.label || '') }
      end.flatten
    end

    module FactoryDecorator
      def build
        ids.map do |id|
          solr_doc = load_docs.find { |doc| doc.id == id }
          next unless solr_doc

          if solr_doc.file_set?
            presenter_class.for(solr_doc)
          elsif Hyrax.config.curation_concerns.include?(solr_doc.hydra_model)
            # look up file set ids and loop through those
            file_set_docs = load_file_set_docs(solr_doc.file_set_ids)
            file_set_docs.map { |doc| presenter_class.for(doc) } if file_set_docs.length
          end
        end.flatten.compact
      end

      private

        # still create the manifest if the parent work has images attached but the child works do not
        def load_file_set_docs(file_set_ids)
          return [] if file_set_ids.nil?

          query("{!terms f=id}#{file_set_ids.join(',')}", rows: 1000)
            .map { |res| ::SolrDocument.new(res) }
        end
    end
  end
end

Hyrax::IiifManifestPresenter.prepend(Hyrax::IiifManifestPresenterDecorator)
Hyrax::IiifManifestPresenter::Factory.prepend(Hyrax::IiifManifestPresenterDecorator::FactoryDecorator)
```