### PR TITLE
[i36] - add template and view file and modify generator

### DIFF
--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -8,7 +8,7 @@
 
 <%
   # OVERRIDE: Hyrax 2.9.6
-  unless current_user.try(:is_admin?) || current_user.try(:is_superadmin?)
+  unless current_user&.has_role?(:admin, Site.instance) || current_user&.has_role?(:superadmin, Site.instance)
     # hide the jpg derivatives
     members = members.reject { |m| m.solr_document['is_derived_ssi'] == 'true' }
     page_count = presenter.total_pages(members.count)

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -1,0 +1,46 @@
+<%# OVERRIDE: Hyrax 2.9.6 %>
+<h2><%= t('.header') %></h2>
+<%# OVERRIDE: Hyrax 2.9.6 to return all item ids %>
+<% array_of_ids = presenter.list_of_item_ids_to_display %>
+<% members = presenter.member_presenters_for(array_of_ids) %>
+<%# OVERRIDE: Hyrax 2.9.6 to hide jpg derivatives for non admin's/superadmin's %>
+<% page_count = presenter.total_pages %>
+
+<%
+  # OVERRIDE: Hyrax 2.9.6
+  unless current_user.try(:is_admin?) || current_user.try(:is_superadmin?)
+    # hide the jpg derivatives
+    members = members.reject { |m| m.solr_document['is_derived_ssi'] == 'true' }
+    page_count = presenter.total_pages(members.count)
+  end
+%>
+
+<% if members.present? %>
+  <% sorted_members = presenter.sort_members_by_identifier(members) %>
+  <table class="table table-striped related-files">
+    <thead>
+      <tr>
+        <th><%= t('.thumbnail') %></th>
+        <th><%= t('.title') %></th>
+        <th><%= t('.date_uploaded') %></th>
+        <th><%= t('.visibility') %></th>
+        <% if can?(:download, sorted_members) %> <th><%= t('.actions') %></th> <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: 'member', collection: sorted_members %>
+    </tbody>
+  </table>
+  <% if page_count > 1 %>
+    <div class="row">
+      <div class="row record-padding col-md-9">
+        <%# OVERRIDE: Hyrax 2.9.6 to use our paginated list %>
+        <%= paginate sorted_members, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
+      </div><!-- /pager -->
+    </div>
+  <% end %>
+<% elsif can? :edit, presenter.id %>
+  <div class="alert alert-warning" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>
+<% else %>
+  <div class="alert alert-warning" role="alert"><%= t('.unauthorized', type: presenter.human_readable_type) %></div>
+<% end %>

--- a/lib/generators/iiif_print/install_generator.rb
+++ b/lib/generators/iiif_print/install_generator.rb
@@ -94,6 +94,11 @@ module IiifPrint
       copy_file 'create_relationships_job_decorator.rb', 'app/jobs/bulkrax/create_relationships_job_decorator.rb'
     end
 
+    def add_work_show_presenter_decorator
+      # supports displaying child works in the UV
+      copy_file 'work_show_presenter_decorator.rb', 'app/presenters/hyrax/work_show_presenter_decorator.rb'
+    end
+
     def gather_work_types
       # check if this is a hyku application
       switch!(Account.first) if defined? Account

--- a/lib/generators/iiif_print/templates/work_show_presenter_decorator.rb
+++ b/lib/generators/iiif_print/templates/work_show_presenter_decorator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module WorkShowPresenterDecorator
+    # OVERRIDE: Hyrax 2.9.6
+    def total_pages(members = nil)
+      # if we're hiding the derivatives, we won't have as many pages to show
+      pages = members.presence || total_items
+
+      (pages.to_f / rows_from_params.to_f).ceil
+    end
+
+    delegate :file_set_ids, to: :solr_document
+
+    # OVERRIDE Hyrax 2.9.6 to remove check for representative_presenter.image? and allow
+    # a fallback to check for images on the child works
+    # @return [Boolean] render a IIIF viewer
+    def iiif_viewer?
+      parent_work_has_files || child_work_has_files
+    end
+
+    def parent_work_has_files
+      Hyrax.config.iiif_image_server? &&
+        representative_id.present? &&
+        representative_presenter.present? &&
+        members_include_viewable_image?
+    end
+
+    def child_work_has_files
+      file_set_ids.present?
+    end
+
+    # OVERRIDE: Hyrax 2.9.6 to return all item ids so we can sort below before paginating
+    def list_of_item_ids_to_display
+      authorized_item_ids
+    end
+
+    def sort_members_by_identifier(members)
+      sorted = members.sort_by { |work| work.try(:identifier) || [] }
+      paginate_members(sorted)
+    end
+
+    def paginate_members(sorted)
+      Kaminari.paginate_array(sorted, total_count: sorted.size).page(current_page).per(rows_from_params)
+    end
+  end
+end
+
+Hyrax::WorkShowPresenter.prepend(Hyrax::WorkShowPresenterDecorator)


### PR DESCRIPTION
ref #36 

- add the template file for `WorkShowPresenterDecorator`
- add `items` partial which uses `#sort_members_by_identifier` found in the decorator
- modify generator to copy decorator over