### PR TITLE
I35 search service

### DIFF
--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -9,20 +9,20 @@ module IiifPrint
 
     # based on Hyrax::WorkShowPresenter#manifest_metadata
     # expects that individual presenters define #iiif_metadata_fields
-    def manifest_metadata
-      fields = iiif_metadata_fields || []
-      metadata = []
-      fields.each do |field|
-        label = Hyrax::Renderers::AttributeRenderer.new(field, nil).label
-        value = send(field)
-        next if value.blank?
-        value = Array.wrap(value) if value.is_a?(String)
-        metadata << {
-          'label' => label,
-          'value' => Array.wrap(value.map { |f| Loofah.fragment(f.to_s).scrub!(:whitewash).to_s })
-        }
-      end
-      metadata
-    end
+    # def manifest_metadata
+    #   fields = iiif_metadata_fields || []
+    #   metadata = []
+    #   fields.each do |field|
+    #     label = Hyrax::Renderers::AttributeRenderer.new(field, nil).label
+    #     value = send(field)
+    #     next if value.blank?
+    #     value = Array.wrap(value) if value.is_a?(String)
+    #     metadata << {
+    #       'label' => label,
+    #       'value' => Array.wrap(value.map { |f| Loofah.fragment(f.to_s).scrub!(:whitewash).to_s })
+    #     }
+    #   end
+    #   metadata
+    # end
   end
 end

--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -4,8 +4,7 @@ module IiifPrint
     extend ActiveSupport::Concern
 
     def search_service
-      Rails.application.routes.url_helpers.solr_document_iiif_search_url(id,
-                                                                         host: request.base_url)
+      Rails.application.routes.url_helpers.solr_document_iiif_search_url(id, host: hostname)
     end
 
     # based on Hyrax::WorkShowPresenter#manifest_metadata

--- a/app/presenters/iiif_print/iiif_manifest_presenter_factory_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_factory_behavior.rb
@@ -1,0 +1,33 @@
+module IiifPrint
+  module IiifManifestPresenterFactoryBehavior
+    # This will override Hyrax::IiifManifestPresenter::Factory#build and introducing
+    # the expected behavior:
+    # - child work images show as canvases in the parent work manifest
+    # - child work images show in the uv on the parent show page
+    # - still create the manifest if the parent work has images attached but the child works do not
+    def build
+      ids.map do |id|
+        solr_doc = load_docs.find { |doc| doc.id == id }
+        next unless solr_doc
+
+        if solr_doc.file_set?
+          presenter_class.for(solr_doc)
+        elsif Hyrax.config.curation_concerns.include?(solr_doc.hydra_model)
+          # look up file set ids and loop through those
+          file_set_docs = load_file_set_docs(solr_doc.file_set_ids)
+          file_set_docs.map { |doc| presenter_class.for(doc) } if file_set_docs.length
+        end
+      end.flatten.compact
+    end
+
+    private
+
+    # still create the manifest if the parent work has images attached but the child works do not
+    def load_file_set_docs(file_set_ids)
+      return [] if file_set_ids.nil?
+
+      query("{!terms f=id}#{file_set_ids.join(',')}", rows: 1000)
+        .map { |res| ::SolrDocument.new(res) }
+    end
+  end
+end

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -26,6 +26,7 @@ module IiifPrint
       # Register actor to handle any IiifPrint upload behaviors before
       #   CreateWithFilesActor gets to them:
       Hyrax::CurationConcern.actor_factory.insert_before Hyrax::Actors::CreateWithFilesActor, IiifPrint::Actors::IiifPrintUploadActor
+      Hyrax::IiifManifestPresenter.prepend(IiifPrint::IiifManifestPresenterBehavior)
     end
   end
 end

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -27,6 +27,7 @@ module IiifPrint
       #   CreateWithFilesActor gets to them:
       Hyrax::CurationConcern.actor_factory.insert_before Hyrax::Actors::CreateWithFilesActor, IiifPrint::Actors::IiifPrintUploadActor
       Hyrax::IiifManifestPresenter.prepend(IiifPrint::IiifManifestPresenterBehavior)
+      Hyrax::IiifManifestPresenter::Factory.prepend(IiifPrint::IiifManifestPresenterFactoryBehavior)
     end
   end
 end

--- a/spec/presenters/iiif_print/iiif_manifest_presenter_behavior_spec.rb
+++ b/spec/presenters/iiif_print/iiif_manifest_presenter_behavior_spec.rb
@@ -8,23 +8,21 @@ RSpec.describe IiifPrint::IiifManifestPresenterBehavior do
       "section_tesim" => ['B'] }
   end
   let(:solr_document) { SolrDocument.new(attributes) }
-  let(:presenter) { Hyrax::NewspaperPagePresenter.new(solr_document, nil) }
+  let(:presenter) { Hyrax::IiifManifestPresenter.new(solr_document) }
   let(:test_request) { ActionDispatch::TestRequest.new({}) }
-
-  before { allow(presenter).to receive(:request).and_return(test_request) }
 
   describe '#search_service' do
     it 'returns the correct URL for the IIIF Search service' do
-      expect(presenter.search_service).to include('abc123/iiif_search')
+      expect(presenter.search_service).to include("#{solr_document.id}/iiif_search")
     end
   end
 
   describe '#manifest_metadata' do
     subject { presenter.manifest_metadata }
 
-    it { is_expected.not_to be_falsey }
+    xit { is_expected.not_to be_falsey }
 
-    it 'returns the correct metadata array for the manifest' do
+    xit 'returns the correct metadata array for the manifest' do
       expect(subject.map { |v| v["label"] }).to include('Page number')
       expect(subject.map { |v| v["value"] }).to include(['B'])
     end


### PR DESCRIPTION
## Take Two

The [hyku](https://github.com/samvera/hyku/pull/1886) application will now detect if there is another implementation of `#search_search`.  If there is, it will use this one provided in the gem.

`Hyrax::IiifManifestPresenter::Factory#build` is now also decorated within the gem instead of in Hyku.

Currently the `#manifest_metadata` method is not fully implemented and because we're prepending `IiifPrint::IiifManifestPresenterBehavior`, it is now breaking the application, commenting it out for now