### PR TITLE
Add `IiifHelper` spec

### DIFF
--- a/spec/helpers/hyrax/iiif_helper_spec.rb
+++ b/spec/helpers/hyrax/iiif_helper_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+# @note This spec was brought over from Hyrax 3.4.2
+# @see https://github.com/samvera/hyrax/blob/afdda8240494ed382301f7d0ab0fd7bafe79185e/spec/helpers/hyrax/iiif_helper_spec.rb
+RSpec.describe Hyrax::IiifHelper, type: :helper do
+  let(:solr_document) { SolrDocument.new }
+  let(:request) { double }
+  let(:ability) { nil }
+  let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, ability, request) }
+  let(:uv_partial_path) { 'hyrax/base/iiif_viewers/universal_viewer' }
+
+  describe '#iiif_viewer_display' do
+    before do
+      allow(helper).to receive(:iiif_viewer_display_partial).with(presenter)
+                                                            .and_return(uv_partial_path)
+    end
+
+    it "renders a partial" do
+      expect(helper).to receive(:render)
+        .with(uv_partial_path, presenter: presenter)
+      helper.iiif_viewer_display(presenter)
+    end
+
+    it "takes options" do
+      expect(helper).to receive(:render)
+        .with(uv_partial_path, presenter: presenter, transcript_id: '123')
+      helper.iiif_viewer_display(presenter, transcript_id: '123')
+    end
+  end
+
+  describe '#iiif_viewer_display_partial' do
+    subject { helper.iiif_viewer_display_partial(presenter) }
+
+    it 'defaults to universal viewer' do
+      expect(subject).to eq uv_partial_path
+    end
+
+    context "with #iiif_viewer override" do
+      let(:iiif_viewer) { :mirador }
+
+      before do
+        allow(presenter).to receive(:iiif_viewer).and_return(iiif_viewer)
+      end
+
+      it { is_expected.to eq 'hyrax/base/iiif_viewers/mirador' }
+    end
+  end
+
+  describe '#universal_viewer_base_url' do
+    subject { helper.universal_viewer_base_url }
+
+    it 'defaults to universal viewer base path' do
+      expect(subject).to eq "http://test.host/uv/uv.html"
+    end
+  end
+
+  describe '#universal_viewer_config_url' do
+    subject { helper.universal_viewer_config_url }
+
+    it 'defaults to universal viewer base path' do
+      expect(subject).to eq "http://test.host/uv/uv-config.json"
+    end
+  end
+end


### PR DESCRIPTION
closes #28

This commit will bring over the `IiifHelper` spec from Hyrax 3.4.2.