### PR TITLE
correct lint errors

### DIFF
--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -53,7 +53,7 @@ module IiifPrint
       hash
     end
 
-    def sanitize_v3(hash:, _presenter:)
+    def sanitize_v3(hash:, **)
       # TODO: flesh out metadata for v3
       hash
     end
@@ -84,7 +84,7 @@ module IiifPrint
       hash
     end
 
-    def sorted_canvases_v3(hash:, _sort_field:)
+    def sorted_canvases_v3(hash:, **)
       # TODO: flesh out metadata for v3
       hash
     end

--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -53,7 +53,7 @@ module IiifPrint
       hash
     end
 
-    def sanitize_v3(hash:, presenter:)
+    def sanitize_v3(hash:, _presenter:)
       # TODO: flesh out metadata for v3
       hash
     end
@@ -84,7 +84,7 @@ module IiifPrint
       hash
     end
 
-    def sorted_canvases_v3(hash:, sort_field:)
+    def sorted_canvases_v3(hash:, _sort_field:)
       # TODO: flesh out metadata for v3
       hash
     end


### PR DESCRIPTION
# Summary

makes keyword arg optional to get past the following lint errors: 

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/10081604/213284655-d8850af4-58b6-473d-a952-6c13478e864d.png">

# Screenshots / Video
<img width="634" alt="image" src="https://user-images.githubusercontent.com/10081604/213285120-ecd35321-712f-4da9-92ac-111d6c47f722.png">

# Expected Behavior
- [ ] the pipeline should pass lint

# Notes
The arguments are not being used because these methods have not been implemented yet.