### PR TITLE
Fix manifest bug

### DIFF
--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -6,7 +6,6 @@ module IiifPrint
                    &block)
       super(*args, iiif_manifest_factory: iiif_manifest_factory, &block)
       @version = version.to_i
-      @presenter_solr_docs = {}
     end
 
     def manifest_for(presenter:)
@@ -63,10 +62,7 @@ module IiifPrint
       # uses the '@id' property which is a URL that contains the FileSet id
       file_set_id = canvas['@id'].split('/').last
       # finds the image that the FileSet is attached to and creates metadata on that canvas
-      image = solr_docs.find do |doc|
-        # TODO: filter out has_model_ssim FileSet in #get_solr_docs
-        doc[:member_ids_ssim]&.include?(file_set_id) && doc[:has_model_ssim] != ["FileSet"]
-      end
+      image = solr_docs.find { |doc| doc[:member_ids_ssim]&.include?(file_set_id) }
       canvas_metadata = IiifPrint.manifest_metadata_for(work: image,
                                                         current_ability: presenter.ability,
                                                         base_url: presenter.base_url)
@@ -90,15 +86,12 @@ module IiifPrint
     end
 
     def get_solr_docs(presenter)
-      @presenter_solr_docs[presenter.id] ||= begin
-        parent_id = [presenter._source['id']]
-        child_ids = presenter._source['member_ids_ssim']
-        parent_id_and_child_ids = parent_id + child_ids
-        # TODO: filter out has_model_ssim FileSet
-        query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids(parent_id_and_child_ids)
-        solr_hits = ActiveFedora::SolrService.query(query, rows: 100_000)
-        solr_hits.map { |solr_hit| ::SolrDocument.new(solr_hit) }
-      end
+      parent_id = [presenter._source['id']]
+      child_ids = presenter._source['member_ids_ssim']
+      parent_id_and_child_ids = parent_id + child_ids
+      query = ActiveFedora::SolrQueryBuilder.construct_query_for_ids(parent_id_and_child_ids)
+      solr_hits = ActiveFedora::SolrService.query(query, fq: "-has_model_ssim:FileSet", rows: 100_000)
+      solr_hits.map { |solr_hit| ::SolrDocument.new(solr_hit) }
     end
   end
 end


### PR DESCRIPTION
There is a weird interaction that happens when a child work gets added to the parent work.  When `#get_solr_docs` got called, it sometimes returned 1 `solr_doc` and when the #find happens, it sometimes returned nothing which resulted in `nil` being set as the image and passed along. This would cause issues further down and result in a failed manifest generation.  I took out `@presenter_solr_docs[presenter.id]` because it wasn't being used and seemed to be the source of the problem.