### PR TITLE
[i76] - Make UV show up if parent has no file set

### DIFF
--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -28,7 +28,7 @@ module IiifPrint
         members_include_viewable_image?
     end
 
-    def child_work_has_files
+    def child_work_has_files?
       file_set_ids.present?
     end
   end

--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -21,7 +21,7 @@ module IiifPrint
 
     private
 
-    def parent_work_has_files
+    def parent_work_has_files?
       Hyrax.config.iiif_image_server? &&
         representative_id.present? &&
         representative_presenter.present? &&

--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module IiifPrint
+  module WorkShowPresenterDecorator
+    # OVERRIDE: Hyrax 2.9.6
+    def total_pages(members = nil)
+      # if we're hiding the derivatives, we won't have as many pages to show
+      pages = members.presence || total_items
+
+      (pages.to_f / rows_from_params.to_f).ceil
+    end
+
+    delegate :file_set_ids, to: :solr_document
+
+    # OVERRIDE Hyrax 2.9.6 to remove check for representative_presenter.image? and allow
+    # a fallback to check for images on the child works
+    # @return [Boolean] render a IIIF viewer
+    def iiif_viewer?
+      parent_work_has_files || child_work_has_files
+    end
+
+    private
+
+    def parent_work_has_files
+      Hyrax.config.iiif_image_server? &&
+        representative_id.present? &&
+        representative_presenter.present? &&
+        members_include_viewable_image?
+    end
+
+    def child_work_has_files
+      file_set_ids.present?
+    end
+  end
+end

--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -2,14 +2,6 @@
 
 module IiifPrint
   module WorkShowPresenterDecorator
-    # OVERRIDE: Hyrax 2.9.6
-    def total_pages(members = nil)
-      # if we're hiding the derivatives, we won't have as many pages to show
-      pages = members.presence || total_items
-
-      (pages.to_f / rows_from_params.to_f).ceil
-    end
-
     delegate :file_set_ids, to: :solr_document
 
     # OVERRIDE Hyrax 2.9.6 to remove check for representative_presenter.image? and allow

--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -16,7 +16,7 @@ module IiifPrint
     # a fallback to check for images on the child works
     # @return [Boolean] render a IIIF viewer
     def iiif_viewer?
-      parent_work_has_files || child_work_has_files
+      parent_work_has_files? || child_work_has_files?
     end
 
     private

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,0 +1,9 @@
+<% if presenter.iiif_viewer? %>
+  <% if defined?(viewer) && viewer %>
+    <%= iiif_viewer_display presenter %>
+  <% else %>
+    <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter %>
+  <% end %>
+<% else %>
+  <%= image_tag 'default.png', class: "canonical-image", alt: 'default representative image' %>
+<% end %>

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -30,6 +30,7 @@ module IiifPrint
       Hyrax::IiifManifestPresenter::Factory.prepend(IiifPrint::IiifManifestPresenterFactoryBehavior)
       Hyrax::ManifestBuilderService.prepend(IiifPrint::ManifestBuilderServiceBehavior)
       Hyrax::WorksControllerBehavior.prepend(IiifPrint::WorksControllerBehaviorDecorator)
+      Hyrax::WorkShowPresenter.prepend(IiifPrint::WorkShowPresenterDecorator)
 
       # Extending the presenter to the base url which includes the protocol.
       # We need the base url to render the facet links and normalize the interface.


### PR DESCRIPTION
ref #76 

This commit will bring over the `WorkShowPresenterDecorator` and the affected view partial from Louisville.  This decorator allows for the Universal Viewer to show up on a parent work that has a child work with a file set, but does not have its own file set.  Previously, the UV would not render.

Reference file:
https://github.com/scientist-softserv/louisville-hyku/blob/main/app/presenters/hyrax/work_show_presenter_decorator.rb

### Before:
<img width="1193" alt="Screenshot 2023-01-24 at 11 03 52 AM" src="https://user-images.githubusercontent.com/19597776/214392091-2217e2a2-c1b6-480a-b190-6a2a7f837294.png">

### After:
<img width="1177" alt="Screenshot 2023-01-24 at 11 08 45 AM" src="https://user-images.githubusercontent.com/19597776/214392135-32c54315-6992-4f68-a9b5-170e0c240df1.png">
