### PR TITLE
[i88] - update readme instructions for enabling ocr catalog search

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ IiifPrint easily integrates with your Hyrax 2.x applications.
 * Run `bundle install`
 * Run `rails generate iiif_print:install`
 * Set config options as indicated below...
-* In the CatalogController, find add_search_fields config block for 'all_fields'. Add advanced_parse: false as seen in the following example: 
+* In the CatalogController, find the add_search_fields config block for 'all_fields'. Add advanced_parse: false, as seen in the following example: 
 ```
     config.add_search_field('all_fields', label: 'All Fields', include_in_advanced_search: false, advanced_parse: false) do |field|
       all_names = config.show_fields.values.map(&:field).join(" ")

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ A complete list of features can be found [here](https://github.com/samvera-labs/
 ## Documentation
 A set of helpful documents to help you learn more and deploy IiifPrint can be found on the [Project Wiki](https://github.com/samvera-labs/iiif_print/wiki), including a PCDM model diagram, metadata schema, batch ingest instructions, and more details on installing, developing, and testing the code.
 
+IiifPrint was developed against Hyku 4.0; If your application uses Bulkrax, please ensure that its version is 5.0.1 or greater. 
+
 ## Requirements
 
   * [Ruby](https://rubyonrails.org/) >=2.4  
@@ -80,6 +82,19 @@ IiifPrint easily integrates with your Hyrax 2.x applications.
 * Run `bundle install`
 * Run `rails generate iiif_print:install`
 * Set config options as indicated below...
+* In the CatalogController, find add_search_fields config block for 'all_fields'. Add advanced_parse: false as seen in the following example: 
+```
+    config.add_search_field('all_fields', label: 'All Fields', include_in_advanced_search: false, advanced_parse: false) do |field|
+      all_names = config.show_fields.values.map(&:field).join(" ")
+      title_name = 'title_tesim'
+      field.solr_parameters = {
+        qf: "#{all_names} file_format_tesim all_text_tsimv",
+        pf: title_name.to_s
+      }
+    end
+```
+* Additionally, find and replace all instances of all_text_timv with all_text_tsimv, in the CatalogController.
+
 
 ## Application/Site Specific Configuration
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ IiifPrint easily integrates with your Hyrax 2.x applications.
 * Run `bundle install`
 * Run `rails generate iiif_print:install`
 * Set config options as indicated below...
+
+TO ENABLE OCR Search (from the UV and catalog search)
 * In the CatalogController, find the add_search_fields config block for 'all_fields'. Add advanced_parse: false, as seen in the following example: 
 ```
     config.add_search_field('all_fields', label: 'All Fields', include_in_advanced_search: false, advanced_parse: false) do |field|
@@ -94,6 +96,10 @@ IiifPrint easily integrates with your Hyrax 2.x applications.
     end
 ```
 * Additionally, find and replace all instances of all_text_timv with all_text_tsimv, in the CatalogController.
+* Remove the following line from iiif_search_builder.rb
+```
+solr_parameters[:qf] = blacklight_config.iiif_search[:full_text_field]
+```
 
 
 ## Application/Site Specific Configuration


### PR DESCRIPTION
# Summary
ref: #88 
Catalog seraching for child metadata and OCR was not working. This MR identifies the manual changes a dev would need to make to fix it. 

At a later date, we may discuss a way for the generator to implement this.

# Expected Behavior

- [ ] From the Parent UV, when a user searches for child metadata and there's a match, it should be highlighted in the UV 
- [ ] When a user performs a catalog search for OCR, the parent should return

# Testing Instructions

This work is dependent upon #81 

A Developer could test this locally. Otherwise, deploy hyku branch i87-ocr-search to hyku-iiif (ref testing instructions in #88 if you deploy) 

Create a new branch, based off of #81 (i81-uv-text-search)
Follow the instructions in the MR

1. Create a work. Upload an image that has text. OCR should run. Confirm that json coordinates are created as its derivatives. Confirm that a user can search for the text in the UV, and find a match.
2. Create a work. Attach a child. Confirm that a user can visit the parent's UV, search for the child's metadata and find a match.
3. A user should able be able to catalog search the child metadata and have its parent return
4. A user should be able to catalog search the child's ocr term and have its parent return


If something appears to not be working, try to reindex first.
