### PR TITLE
Further tidying of specs

### DIFF
--- a/iiif_print.gemspec
+++ b/iiif_print.gemspec
@@ -8,16 +8,16 @@ Gem::Specification.new do |spec|
   spec.name        = 'iiif_print'
   spec.version     = IiifPrint::VERSION
   spec.authors     = ['Sean Upton', 'Jacob Reed', 'Brian McBride',
-                      'Eben English']
+                      'Eben English', 'Kirk Wang', 'LaRita Robinson', 'Jeremy Friesen']
   spec.email       = ['sean.upton@utah.edu', 'jacob.reed@utah.edu',
-                      'brian.mcbride@utah.edu', 'eenglish@bpl.org']
+                      'brian.mcbride@utah.edu', 'eenglish@bpl.org', 'kirk.wang@scientist.com',
+                      'larita@scientist.com', 'jeremy.n.friesen@gmail.com']
   spec.homepage    = 'https://github.com/samvera-labs/iiif_print'
-  spec.description = 'Gem/Engine for Newspaper Works in Hyrax-based Samvera
-                      Application.'
+  spec.description = 'Gem/Engine for IIIF Print works in Hyrax-based Samvera Application.'
   spec.summary     = <<-SUMMARY
   iiif_print is a Rails Engine gem providing model and administrative
   functions to Hyrax-based Samvera applications, for management of
-  (primarily scanned) archival newspaper content.
+  (primarily scanned) content.
 SUMMARY
   spec.license = 'Apache-2.0'
   spec.files = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)

--- a/spec/services/iiif_print/pluggable_derivative_service_spec.rb
+++ b/spec/services/iiif_print/pluggable_derivative_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe IiifPrint::PluggableDerivativeService do
 
     it "is the first valid service found" do
       found = Hyrax::DerivativeService.for(FileSet.new)
-      expect(found.class).to be described_class
+      expect(found).to be_a described_class
     end
   end
 
@@ -57,10 +57,11 @@ RSpec.describe IiifPrint::PluggableDerivativeService do
       let(:work) { MyIiifConfiguredWork.new }
 
       it "calls each plugin on create" do
+        plugins = [FakeDerivativeService]
         create_calls = FakeDerivativeService.create_called
-        service = described_class.new(persisted_file_set)
+        service = described_class.new(persisted_file_set, plugins: plugins)
         service.create_derivatives('not_a_real_filename')
-        expect(FakeDerivativeService.create_called).to eq create_calls + 2
+        expect(FakeDerivativeService.create_called).to eq create_calls + plugins.size
       end
 
       def touch_fake_derivative_file(file_set, ext)
@@ -85,9 +86,10 @@ RSpec.describe IiifPrint::PluggableDerivativeService do
 
       it "calls each plugin on cleanup" do
         expect(FakeDerivativeService.cleanup_called).to eq 0
-        service = described_class.new(persisted_file_set)
+        plugins = [FakeDerivativeService]
+        service = described_class.new(persisted_file_set, plugins: plugins)
         service.cleanup_derivatives
-        expect(FakeDerivativeService.cleanup_called).to eq 2
+        expect(FakeDerivativeService.cleanup_called).to eq plugins.size
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -158,17 +158,17 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  # config.profile_examples = 10
+  config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  # config.order = :random
+  config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
-  # Kernel.srand config.seed
+  Kernel.srand config.seed
 end

--- a/spec/support/iiif_print_models.rb
+++ b/spec/support/iiif_print_models.rb
@@ -73,10 +73,7 @@ end
 
 class MyIiifConfiguredWork < ActiveFedora::Base
   include IiifPrint.model_configuration(
-    derivative_service_plugins: [
-      FakeDerivativeService,
-      FakeDerivativeService
-    ]
+    derivative_service_plugins: [FakeDerivativeService]
   )
   attr_accessor :title
   def members


### PR DESCRIPTION
## Amending gemspec to tidy up descriptions and attribution

ea30d93c3d3878474a4cb1340b0145e9e5a30d90


## Removing side-effect causing bug in setting plugins

68a565886051ccbc5da518eaa971c64172e05659

The primary purpose of this commit is to remediate the following code:

```ruby
def default_plugin_for(file_set)
  if file_set.parent.try(:iiif_print_config?)
    file_set.parent.iiif_print_config.derivative_service_plugins << default_plugin
  else
    [default_plugin]
  end
end
```

As written, the above method was changing the configuration for a work's
parent.  Due to the implementation of the parent's `#iiif_print_config`
it was an isolated update (e.g. updating only the parent object's value
and not the parent object's class's value).

I found this bug by introducting random spec order.

With this commit, I'm doing a few things:

1. Reworking the `plugins_for` method; instead of updating the value, it
   uses that value to set the local `@plugins` instance varaible.
2. Moving methods to group like concepts (e.g. `attr_reader`
   declarations)
3. Extracting `class_attributes` to provide some configurable options.
4. Changing a spec to not test class equality, which does not allow for
   subclass comparison, but to instead test if the object is a
   class (which allows for subclass equality).
5. Leveraging the already existent dependency injection to test some of
   the behavior.
6. Removing the tightly coupled `eq 2` test, which needed to have
   knowledge about the number of `derivative_service_plugins` registered
   for the model.
7. Introducing random rspec run order.  This helps find temporal
   couplings that can cause production issues.
