### PR TITLE
Reworking configuration options

### DIFF
--- a/app/services/iiif_print/pluggable_derivative_service.rb
+++ b/app/services/iiif_print/pluggable_derivative_service.rb
@@ -51,7 +51,7 @@ class IiifPrint::PluggableDerivativeService
     result = plugins.map { |plugin| plugin.new(file_set) }.select(&:valid?)
     result.select do |plugin|
       dest = nil
-      dest = plugin.class.target_ext if plugin.class.respond_to?(:target_ext)
+      dest = plugin.class.target_extension if plugin.class.respond_to?(:target_extension)
       !skip_destination?(method_name, dest)
     end
   end

--- a/lib/iiif_print/base_derivative_service.rb
+++ b/lib/iiif_print/base_derivative_service.rb
@@ -4,10 +4,10 @@ module IiifPrint
     attr_reader :file_set, :master_format
     delegate :uri, to: :file_set
 
-    TARGET_EXT = nil
+    TARGET_EXTENSION = nil
 
-    def self.target_ext
-      self::TARGET_EXT
+    def self.target_extension
+      self::TARGET_EXTENSION
     end
 
     def initialize(file_set)
@@ -43,7 +43,7 @@ module IiifPrint
     # calculate and ensure directory components for singular @dest_path
     #   should only be used by subclasses producing a single derivative
     def load_destpath
-      @dest_path = prepare_path(self.class.target_ext)
+      @dest_path = prepare_path(self.class.target_extension)
     end
 
     def identify
@@ -69,14 +69,14 @@ module IiifPrint
       @source_path = filename
 
       # Get destination path from Hyrax for file extension defined in
-      #   TARGET_EXT constant on respective derivative service subclass.
+      #   TARGET_EXTENSION constant on respective derivative service subclass.
       load_destpath
     end
 
     def cleanup_derivatives(*args)
-      target_ext = args && args[0] ? args[0] : self.class.target_ext
+      target_extension = args && args[0] ? args[0] : self.class.target_extension
       derivative_path_factory.derivatives_for_reference(file_set).each do |path|
-        FileUtils.rm_f(path) if path.ends_with?(target_ext)
+        FileUtils.rm_f(path) if path.ends_with?(target_extension)
       end
     end
 

--- a/lib/iiif_print/base_derivative_service.rb
+++ b/lib/iiif_print/base_derivative_service.rb
@@ -4,11 +4,7 @@ module IiifPrint
     attr_reader :file_set, :master_format
     delegate :uri, to: :file_set
 
-    TARGET_EXTENSION = nil
-
-    def self.target_extension
-      self::TARGET_EXTENSION
-    end
+    class_attribute :target_extension, default: nil
 
     def initialize(file_set)
       @file_set = file_set
@@ -43,7 +39,7 @@ module IiifPrint
     # calculate and ensure directory components for singular @dest_path
     #   should only be used by subclasses producing a single derivative
     def load_destpath
-      @dest_path = prepare_path(self.class.target_extension)
+      @dest_path = prepare_path(target_extension)
     end
 
     def identify
@@ -69,14 +65,13 @@ module IiifPrint
       @source_path = filename
 
       # Get destination path from Hyrax for file extension defined in
-      #   TARGET_EXTENSION constant on respective derivative service subclass.
+      #   self.target_extension constant on respective derivative service subclass.
       load_destpath
     end
 
-    def cleanup_derivatives(*args)
-      target_extension = args && args[0] ? args[0] : self.class.target_extension
+    def cleanup_derivatives(extension = target_extension, *_args)
       derivative_path_factory.derivatives_for_reference(file_set).each do |path|
-        FileUtils.rm_f(path) if path.ends_with?(target_extension)
+        FileUtils.rm_f(path) if path.ends_with?(extension)
       end
     end
 

--- a/lib/iiif_print/jp2_derivative_service.rb
+++ b/lib/iiif_print/jp2_derivative_service.rb
@@ -20,7 +20,7 @@ module IiifPrint
     CMD_1X = 'image_to_j2k'.freeze
 
     # Target file extension of this service plugin:
-    TARGET_EXT = 'jp2'.freeze
+    TARGET_EXTENSION = 'jp2'.freeze
 
     attr_reader :file_set
     delegate :uri, :mime_type, to: :file_set

--- a/lib/iiif_print/jp2_derivative_service.rb
+++ b/lib/iiif_print/jp2_derivative_service.rb
@@ -20,7 +20,7 @@ module IiifPrint
     CMD_1X = 'image_to_j2k'.freeze
 
     # Target file extension of this service plugin:
-    TARGET_EXTENSION = 'jp2'.freeze
+    self.target_extension = 'jp2'.freeze
 
     attr_reader :file_set
     delegate :uri, :mime_type, to: :file_set

--- a/lib/iiif_print/pdf_derivative_service.rb
+++ b/lib/iiif_print/pdf_derivative_service.rb
@@ -2,7 +2,7 @@ require 'open3'
 
 module IiifPrint
   class PDFDerivativeService < BaseDerivativeService
-    TARGET_EXTENSION = 'pdf'.freeze
+    self.target_extension = 'pdf'.freeze
 
     # PDF (JPEG, 8 bit grayscale), 150ppi
     GRAY_PDF_CMD = 'convert %<source_file>s ' \

--- a/lib/iiif_print/pdf_derivative_service.rb
+++ b/lib/iiif_print/pdf_derivative_service.rb
@@ -2,7 +2,7 @@ require 'open3'
 
 module IiifPrint
   class PDFDerivativeService < BaseDerivativeService
-    TARGET_EXT = 'pdf'.freeze
+    TARGET_EXTENSION = 'pdf'.freeze
 
     # PDF (JPEG, 8 bit grayscale), 150ppi
     GRAY_PDF_CMD = 'convert %<source_file>s ' \

--- a/lib/iiif_print/text_formats_from_alto_service.rb
+++ b/lib/iiif_print/text_formats_from_alto_service.rb
@@ -4,7 +4,7 @@ module IiifPrint
   #   NOTE: to keep this from conflicting with TextExtractionDerivativeService,
   #         this class should be invoked by it, not PluggableDerivativeService.
   class TextFormatsFromALTOService < BaseDerivativeService
-    TARGET_EXTENSION = 'tiff'.freeze
+    self.target_extension = 'tiff'.freeze
 
     def save_derivative(destination, data)
       # Load/prepare base of "pairtree" dir structure for extension, fileset

--- a/lib/iiif_print/text_formats_from_alto_service.rb
+++ b/lib/iiif_print/text_formats_from_alto_service.rb
@@ -4,7 +4,7 @@ module IiifPrint
   #   NOTE: to keep this from conflicting with TextExtractionDerivativeService,
   #         this class should be invoked by it, not PluggableDerivativeService.
   class TextFormatsFromALTOService < BaseDerivativeService
-    TARGET_EXT = 'tiff'.freeze
+    TARGET_EXTENSION = 'tiff'.freeze
 
     def save_derivative(destination, data)
       # Load/prepare base of "pairtree" dir structure for extension, fileset

--- a/lib/iiif_print/tiff_derivative_service.rb
+++ b/lib/iiif_print/tiff_derivative_service.rb
@@ -2,7 +2,7 @@ require 'open3'
 
 module IiifPrint
   class TIFFDerivativeService < BaseDerivativeService
-    TARGET_EXT = 'tiff'.freeze
+    TARGET_EXTENSION = 'tiff'.freeze
 
     # For imagemagick commands, the output type is determined by the
     #   output file's extension.

--- a/lib/iiif_print/tiff_derivative_service.rb
+++ b/lib/iiif_print/tiff_derivative_service.rb
@@ -2,7 +2,7 @@ require 'open3'
 
 module IiifPrint
   class TIFFDerivativeService < BaseDerivativeService
-    TARGET_EXTENSION = 'tiff'.freeze
+    self.target_extension = 'tiff'.freeze
 
     # For imagemagick commands, the output type is determined by the
     #   output file's extension.

--- a/spec/support/iiif_print_models.rb
+++ b/spec/support/iiif_print_models.rb
@@ -13,7 +13,7 @@ class FakeDerivativeService
   class << self
     attr_accessor :create_called, :cleanup_called
 
-    def target_ext
+    def target_extension
       'txt'
     end
   end


### PR DESCRIPTION
## Renaming target_ext to target_extension

e1abf3edd59920b6038961459131bc7db5ab1525

Prior to this commit, we used an abbreviation for an undocumented
method.  To understand purpose, we need to read more about its
implementation.

With this commit, I'm renaming the method/constant to a more verbose
variable.  We have to read it more often than we will ever write it.

## Favoring `class_attribute` over constant

ac4cb0a2cfda49315216589d0539aac3d0fa4e50

Prior to this commit, we were using a constant and class method to
handle the configurability of the `target_extension`.

With this commit, we remove the constant and provide a class attribute
that allows for configuration and exposes an instance method.

Also, instead of using the terinary args test, I've added a positional
parameter with a default value.
