### PR TITLE
Refactoring specs to remove warning

### DIFF
--- a/spec/models/iiif_print/derivative_attachment_spec.rb
+++ b/spec/models/iiif_print/derivative_attachment_spec.rb
@@ -15,7 +15,7 @@ module IiifPrint
         destination_name: 'txt'
       )
       # attempt save without required data; expect failure
-      expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)
+      expect { model.save! }.not_to raise_exception
     end
 
     it "saves when all fields completely set" do
@@ -23,7 +23,7 @@ module IiifPrint
       model.fileset_id = 'someid123'
       model.path = '/path/to/somefile'
       model.destination_name = 'txt'
-      expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)
+      expect { model.save! }.not_to raise_exception
     end
 
     it "saves when only path, destination_name set" do
@@ -31,7 +31,7 @@ module IiifPrint
       model.fileset_id = nil
       model.path = '/path/to/somefile'
       model.destination_name = 'txt'
-      expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)
+      expect { model.save! }.not_to raise_exception
     end
   end
 end

--- a/spec/models/iiif_print/ingest_file_relation_spec.rb
+++ b/spec/models/iiif_print/ingest_file_relation_spec.rb
@@ -36,14 +36,14 @@ module IiifPrint
         file_path: '/path/to/this',
         derivative_path: '/path/to/that'
       )
-      expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)
+      expect { model.save! }.not_to raise_exception
     end
 
     it "will save when all fields completely set" do
       model = described_class.create
       model.file_path = '/path/to/sourcefile.tiff'
       model.derivative_path = '/path/to/derived.jp2'
-      expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)
+      expect { model.save! }.not_to raise_exception
     end
 
     it "can query derivative paths for primary file" do


### PR DESCRIPTION
## Adjusting method PluggableDerivativeService implementation

e7e0675580cfbc3cbf6e472ca1e8354859d0e979

Prior to this commit, the `respond_to_missing?` method definition did
not have the correct method signature.  Which could cause failures
elsewhere.

Also, as much as we don't want to repeat knowledge regarding
implementation details, most references to method_missing and the
sibling respond_to_missing duplicate logic; in part to minimize
unnecessary calls.  (See [Always Define respond_to_missing?][1])

I renamed `name` to `method_name` to be consistent with the
parameters of the sibling methods.

And last, I made a change in the logic test to short-circuit faster and
not reference the file_set if we don't have "agreeable" parameters.

References:

- https://github.com/scientist-softserv/iiif_print/issues/43

[1]: https://thoughtbot.com/blog/always-define-respond-to-missing-when-overriding

## Removing RSpec matcher warning

ba0268f0d735a728c0face320af9389df5517949

Prior to this commit the specs included the following warning:

> WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)`
> risks false positives, since literally any other error would cause the
> expectation to pass, including those raised by Ruby
> (e.g. NoMethodError, NameError and ArgumentError), meaning the
> code you are intending to test may not even get reached. Instead
> consider using `expect { }.not_to raise_error` or `expect { }.to
> raise_error(DifferentSpecificErrorClass)`.

With this commit, we're removing that warning.

Less warnings, means less chatter.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/43
