### PR TITLE
Removing deprecation warnings and renaming variable

### DIFF
--- a/app/actors/iiif_print/actors/iiif_print_upload_actor.rb
+++ b/app/actors/iiif_print/actors/iiif_print_upload_actor.rb
@@ -88,7 +88,9 @@ module IiifPrint
       end
 
       def default_admin_set
-        AdminSet.find_or_create_default_admin_set_id
+        return AdminSet.find_or_create_default_admin_set_id unless defined?(Hyrax::AdminSetCreateService)
+
+        Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
       end
 
       # Given Hyrax::Upload object, return path to file on local filesystem

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -9,6 +9,19 @@ module IiifPrint
       @excluded_model_name_solr_field_values = []
     end
 
+    # This method wraps Hyrax's configuration so we can sniff out the correct method to use.  The
+    # {Hyrax::Configuration#whitelisted_ingest_dirs} is deprecated in favor of
+    # {Hyrax::Configuration#registered_ingest_dirs}.
+    #
+    # @return [Array<String>]
+    def registered_ingest_dirs
+      if Hyrax.config.respond_to?(:registered_ingest_dirs)
+        Hyrax.config.registered_ingest_dirs
+      else
+        Hyrax.config.whitelisted_ingest_dirs
+      end
+    end
+
     attr_writer :excluded_model_name_solr_field_key
     # A string of a solr field key
     # @return [String]

--- a/lib/iiif_print/data/path_helper.rb
+++ b/lib/iiif_print/data/path_helper.rb
@@ -17,8 +17,8 @@ module IiifPrint
         isuri?(path) ? path : "file://#{path}"
       end
 
-      def whitelisted_path(path)
-        Hyrax.config.whitelisted_ingest_dirs.any? do |dir|
+      def registered_ingest_path(path)
+        IiifPrint.config.registered_ingest_dirs.any? do |dir|
           path.start_with?(dir) && path.length > dir.length
         end
       end
@@ -28,11 +28,11 @@ module IiifPrint
         path = File.expand_path(path.sub(/^file:\/\//, ''))
         # make sure file exists
         raise IOError, "Not found: #{path}" unless File.exist?(path)
-        return if whitelisted_path(path)
-        # we cannot use path if it is not whitelisted for Hyrax ingest, we
+        return if registered_ingest_path(path)
+        # we cannot use path if it is not in the registered list for Hyrax ingest, we
         #   would prefer to fail early vs. later+silently
         raise SecurityError,
-          "Path specified is not configured in Hyrax ingest whitelist: " \
+          "Path specified is not configured in Hyrax ingest registered list: " \
           "#{path}"
       end
     end

--- a/spec/lib/iiif_print/data/work_derivatives_spec.rb
+++ b/spec/lib/iiif_print/data/work_derivatives_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe IiifPrint::Data::WorkDerivatives do
   let(:adapter) { described_class.new(work) }
 
   let(:txt1) do
-    whitelist = Hyrax.config.whitelisted_ingest_dirs
-    whitelist.push('/tmp') unless whitelist.include?('/tmp')
+    registered_dirs = IiifPrint.config.registered_ingest_dirs
+    registered_dirs.push('/tmp') unless registered_dirs.include?('/tmp')
     file = Tempfile.new(['txt1', '.txt'])
     file.write('hello')
     file.flush
@@ -117,7 +117,7 @@ RSpec.describe IiifPrint::Data::WorkDerivatives do
       expect(adapter.assigned).to include example_gray_jp2
     end
 
-    xit "will fail to assign file in non-whitelisted dir" do
+    xit "will fail to assign file in non-registered dirs" do
       adapter = described_class.new(bare_work)
       # need a non-whitlisted file that exists:
       bad_path = File.expand_path("../../spec_helper.rb", fixture_path)

--- a/spec/lib/iiif_print/data/work_files_spec.rb
+++ b/spec/lib/iiif_print/data/work_files_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe IiifPrint::Data::WorkFiles do
       expect(adapter.assigned).to include tiff_path
     end
 
-    it "will fail to assign file in non-whitelisted dir" do
+    it "will fail to assign file in non registered dir" do
       adapter = described_class.new(work)
-      # need a non-whitlisted file that exists:
+      # need a non-registered file that exists:
       bad_path = File.expand_path("../../spec_helper.rb", fixture_path)
       expect { adapter.assign(bad_path) }.to raise_error(SecurityError)
     end
@@ -141,7 +141,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
   end
 
   describe "commits changes" do
-    # These jobs we need whitelisted to run now, at minimum:
+    # We need to register these jobs to run now, at minimum:
     do_now_jobs = [IngestLocalFileJob, IngestJob, InheritPermissionsJob]
     # These we skip: [CharacterizeJob, CreateDerivativesJob]
     #   -- skipping these saves 10-15 seconds on attachment example
@@ -198,7 +198,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
       adapter = described_class.of(work)
       adapter.assign(tiff_path)
       adapter.commit!
-      # whitelisted jobs (do_now_jobs) performed as effect of commit!
+      # registered jobs (do_now_jobs) performed as effect of commit!
       #   are configured to effectively run inline. Reloading work
       #   should refresh the work.members, and by consequence adapter.keys
       work.reload

--- a/spec/misc_shared.rb
+++ b/spec/misc_shared.rb
@@ -3,8 +3,10 @@ RSpec.shared_context "shared setup", shared_context: :metadata do
     path = File.join(
       IiifPrint::GEM_PATH, 'spec', 'fixtures', 'files'
     )
-    whitelist = Hyrax.config.whitelisted_ingest_dirs
-    whitelist.push(path) unless whitelist.include?(path)
+    # TODO: NOTE: this has potential timing issues in the specs, because we're adjusting the
+    # configured value during the spec run.
+    registered = Hyrax.config.registered_ingest_dirs
+    registered.push(path) unless registered.include?(path)
     path
   end
 


### PR DESCRIPTION
This commit changes the code to remove the following deprecation warnings:

```shell
DEPRECATION WARNING: You are using deprecated behavior which will be
removed from the next major or minor release. (called from
default_admin_set at
/app/samvera/hyrax-webapp/app/actors/iiif_print/actors/iiif_print_upload_actor.rb:91
```

```shell
DEPRECATION WARNING: Samvera is deprecating
Hyrax::Configuration#whitelisted_ingest_dirs in Hyrax 3.0. Instead use
Hyrax::Configuration#registered_ingest_dirs.
```

Further, it renames whitelist variables to registered, to echo the upstream `Hyrax::Configuration#whitelisted_ingest_dirs` deprecation advice.