### PR TITLE
Low-stakes refactoring with todo items

### DIFF
--- a/app/services/iiif_print/pluggable_derivative_service.rb
+++ b/app/services/iiif_print/pluggable_derivative_service.rb
@@ -51,7 +51,7 @@ class IiifPrint::PluggableDerivativeService
     result = plugins.map { |plugin| plugin.new(file_set) }.select(&:valid?)
     result.select do |plugin|
       dest = nil
-      dest = plugin.class.target_extension if plugin.class.respond_to?(:target_extension)
+      dest = plugin.target_extension if plugin.respond_to?(:target_extension)
       !skip_destination?(method_name, dest)
     end
   end

--- a/app/services/iiif_print/pluggable_derivative_service.rb
+++ b/app/services/iiif_print/pluggable_derivative_service.rb
@@ -41,10 +41,6 @@ class IiifPrint::PluggableDerivativeService
     true
   end
 
-  def respond_to_missing?(method_name, include_private = false)
-    allowed_methods.include?(method_name) || super
-  end
-
   # get derivative services relevant to method name and file_set context
   #   -- omits plugins if particular destination exists or will soon.
   def services(method_name)
@@ -56,6 +52,12 @@ class IiifPrint::PluggableDerivativeService
     end
   end
 
+  private
+
+  def respond_to_missing?(method_name, include_private = false)
+    allowed_methods.include?(method_name) || super
+  end
+
   def method_missing(method_name, *args, **opts, &block)
     if allowed_methods.include?(method_name)
       # we have an allowed method, construct services and include all valid
@@ -63,14 +65,12 @@ class IiifPrint::PluggableDerivativeService
       # services = plugins.map { |plugin| plugin.new(file_set) }.select(&:valid?)
       # run all valid services, in order:
       services(method_name).each do |plugin|
-        plugin.send(method_name, *args)
+        plugin.send(method_name, *args, **opts, &block)
       end
     else
       super
     end
   end
-
-  private
 
   def skip_destination?(method_name, destination_name)
     return false unless method_name == :create_derivatives

--- a/lib/iiif_print/jobs/application_job.rb
+++ b/lib/iiif_print/jobs/application_job.rb
@@ -1,5 +1,7 @@
 module IiifPrint
   module Jobs
+    # TODO: Consider inheriting from ::Application job.  That means we would have the upstreams
+    # based job behavior.
     class ApplicationJob < ActiveJob::Base
     end
   end

--- a/lib/iiif_print/jobs/create_relationships_job.rb
+++ b/lib/iiif_print/jobs/create_relationships_job.rb
@@ -15,6 +15,9 @@ module IiifPrint
           @pending_children.each(&:destroy)
         else
           # reschedule the job and end this one normally
+          #
+          # TODO: Depending on how things shake out, we could be infinitely rescheduling this job.
+          # Consider a time to live parameter.
           reschedule(user: user, parent_id: parent_id, parent_model: parent_model, child_model: child_model)
         end
       end


### PR DESCRIPTION
## Adding some todo items based on my code read

e8355e3c0a5e6e98225f31144c383949fef0ab8b


## Favoring instance method for class_attribute

945472551e18a28787bea23cb41283289fcf725d

It is almost always better to reduce method chaining (e.g. `a.b.c.d`
moves to `a.d`).  See the [Law of Demeter][1], or the "Principle of
Least Knowledge."

In other words, I can know my neighbor, but I don't know (as well) my
neighbor's neighbor.

This refactor is made possible by introducing a [class_attribute][2] for
`target_extension`.

[1]: https://en.wikipedia.org/wiki/Law_of_Demeter
[2]: https://api.rubyonrails.org/classes/Class.html#method-i-class_attribute

## Privatizing methods

8128923aa71eb4efc22b7abf17223a0b95f58eff

Prior to this commit, some of the methods were public when they need
not, nor probably should've been.  (Directly calling method_missing is
an anti-pattern).

With this commit, I'm moving methods to a private state.  Ideally, I'd
like the "services" method to also be private but there's a public test
of that.

Further, I'm ensuring that the passed parameters to the method_missing
are propogated to the allowed_methods.
