### PR TITLE
Favoring instance over class for specs

### DIFF
--- a/spec/services/iiif_print/pluggable_derivative_service_spec.rb
+++ b/spec/services/iiif_print/pluggable_derivative_service_spec.rb
@@ -55,13 +55,13 @@ RSpec.describe IiifPrint::PluggableDerivativeService do
       end
 
       let(:work) { MyIiifConfiguredWork.new }
+      let(:plugin) { FakeDerivativeService.new }
 
       it "calls each plugin on create" do
-        plugins = [FakeDerivativeService]
-        create_calls = FakeDerivativeService.create_called
-        service = described_class.new(persisted_file_set, plugins: plugins)
-        service.create_derivatives('not_a_real_filename')
-        expect(FakeDerivativeService.create_called).to eq create_calls + plugins.size
+        service = described_class.new(persisted_file_set, plugins: [plugin])
+        expect do
+          service.create_derivatives('not_a_real_filename')
+        end.to change(plugin, :create_called).by(1)
       end
 
       def touch_fake_derivative_file(file_set, ext)
@@ -71,25 +71,17 @@ RSpec.describe IiifPrint::PluggableDerivativeService do
       end
 
       it "does not re-create existing derivative" do
-        create_calls = FakeDerivativeService.create_called
-        service = described_class.new(persisted_file_set)
+        service = described_class.new(persisted_file_set, plugins: [plugin])
         expect(persisted_file_set.id).not_to be_nil
-        # Fake is configured to have 'txt' destination_path, let's create a
-        #   destination file in Hyrax's opinionated plate for dest. name.
-        touch_fake_derivative_file(persisted_file_set, 'txt')
-        service.create_derivatives('/nonsense/source/path/ignored')
-        # create calls logged by fake should not increment,
-        #   as PluggableDerivativeService should have skipped calling
-        #   plugin's create_derivatives method w/ presence of existing derivative
-        expect(FakeDerivativeService.create_called).to eq create_calls
+        expect do
+          touch_fake_derivative_file(persisted_file_set, plugin.target_extension)
+          service.create_derivatives('/nonsense/source/path/ignored ')
+        end.not_to change(plugin, :create_called)
       end
 
       it "calls each plugin on cleanup" do
-        expect(FakeDerivativeService.cleanup_called).to eq 0
-        plugins = [FakeDerivativeService]
-        service = described_class.new(persisted_file_set, plugins: plugins)
-        service.cleanup_derivatives
-        expect(FakeDerivativeService.cleanup_called).to eq plugins.size
+        service = described_class.new(persisted_file_set, plugins: [plugin])
+        expect { service.cleanup_derivatives }.to change(plugin, :cleanup_called).by(1)
       end
     end
 


### PR DESCRIPTION
Prior to this commit, the `FakeDerivativeService` leveraged a class instance variable.  This is a precarious implementation as we don't reset the variable in-between runs.

With this commit, we're shifting this "spy" class to be an instance of the class (thus the tracking values are isolated to each spec run).  We do this by having the "spy" conform to the interface of a plugin.

Related to:

-  https://github.com/scientist-softserv/iiif_print/issues/43