### PR TITLE
Moving generated file into engine app

### DIFF
--- a/app/renderers/hyrax/renderers/faceted_attribute_renderer_decorator.rb
+++ b/app/renderers/hyrax/renderers/faceted_attribute_renderer_decorator.rb
@@ -9,14 +9,10 @@ module Hyrax
 
       # OVERRIDE Hyrax 2.9.6 to give user ability to display child works form linked facets
       def search_path(value)
-        path = Rails.application.routes.url_helpers.search_catalog_path(
-          "f[#{search_field}][]": value, locale: I18n.locale
-        )
+        path = super(value)
         path += '&include_child_works=true' if options[:is_child_bsi] == true
         path
       end
     end
   end
 end
-
-Hyrax::Renderers::FacetedAttributeRenderer.prepend(Hyrax::Renderers::FacetedAttributeRendererDecorator)

--- a/lib/generators/iiif_print/install_generator.rb
+++ b/lib/generators/iiif_print/install_generator.rb
@@ -71,11 +71,5 @@ module IiifPrint
     def inject_assets
       generate 'iiif_print:assets'
     end
-
-    # TODO: Consider not copying the decorator.
-    def add_faceted_attribute_decorator
-      # supports display of children in index and search
-      copy_file 'faceted_attribute_renderer_decorator.rb', 'app/renderers/hyrax/renderers/faceted_attribute_renderer_decorator.rb'
-    end
   end
 end

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -29,6 +29,7 @@ module IiifPrint
       Hyrax::IiifManifestPresenter.prepend(IiifPrint::IiifManifestPresenterBehavior)
       Hyrax::IiifManifestPresenter::Factory.prepend(IiifPrint::IiifManifestPresenterFactoryBehavior)
       Hyrax::ManifestBuilderService.prepend(IiifPrint::ManifestBuilderServiceBehavior)
+      Hyrax::Renderers::FacetedAttributeRenderer.prepend(Hyrax::Renderers::FacetedAttributeRendererDecorator)
       Hyrax::WorksControllerBehavior.prepend(IiifPrint::WorksControllerBehaviorDecorator)
       Hyrax::WorkShowPresenter.prepend(IiifPrint::WorkShowPresenterDecorator)
 


### PR DESCRIPTION
Prior to this commit, we were generating this decorator into the downstream application.  Thus this engine cedes control to the downstream application.

However, based on discussions, the `is_child_bsi` may not be in all implementations.  Which would mean we want this decoration to be configurable.

With this commit, we favor keeping the decorator inside the engine thus allowing for future configurability.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/40