### PR TITLE
Favoring `is_a?` over `class ==`

### DIFF
--- a/lib/iiif_print/data/fileset_helper.rb
+++ b/lib/iiif_print/data/fileset_helper.rb
@@ -5,7 +5,7 @@ module IiifPrint
     module FilesetHelper
       def fileset_id
         # if context is itself a string, presume it is a file set id
-        return @work if @work.class == String
+        return @work if @work.is_a? String
         # if context is not a String, presume a work or fileset context:
         fileset.nil? ? nil : fileset.id
       end
@@ -13,11 +13,11 @@ module IiifPrint
       def first_fileset
         # if context is fileset id (e.g. caller is view partial) string,
         #   get the fileset from that id
-        return FileSet.find(@work) if @work.class == String
+        return FileSet.find(@work) if @work.is_a?(String)
         # if "work" context is a FileSet, not actual work, return it
-        return @work if @work.class == FileSet
+        return @work if @work.is_a? FileSet
         # in most cases, get from work's members:
-        filesets = @work.members.select { |m| m.class == FileSet }
+        filesets = @work.members.select { |m| m.is_a? FileSet }
         filesets.empty? ? nil : filesets[0]
       end
     end

--- a/lib/iiif_print/data/work_derivatives.rb
+++ b/lib/iiif_print/data/work_derivatives.rb
@@ -142,7 +142,7 @@ module IiifPrint
         mkdir_pairtree
         path = path_factory.derivative_path_for_reference(fileset, name)
         # if file argument is path, copy file
-        if file.class == String
+        if file.is_a? String
           FileUtils.copy(file, path)
         else
           # otherwise, presume file is an IO, read, write it

--- a/lib/iiif_print/data/work_files.rb
+++ b/lib/iiif_print/data/work_files.rb
@@ -153,7 +153,7 @@ module IiifPrint
 
       def filesets
         # file sets with non-nil original file contained:
-        work.members.select { |m| m.class == FileSet && m.original_file }
+        work.members.select { |m| m.is_a? FileSet && m.original_file }
       end
 
       def user

--- a/spec/iiif_print/data/work_derivatives_spec.rb
+++ b/spec/iiif_print/data/work_derivatives_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe IiifPrint::Data::WorkDerivatives do
     end
 
     xit "enumerates expected derivative extension for file set" do
-      file_set = work.members.find { |m| m.class == FileSet }
+      file_set = work.members.detect { |m| m.is_a? FileSet }
       adapter = described_class.new(file_set)
       ext_found = adapter.keys
       expect(ext_found).to include 'txt'
     end
 
     xit "enumerates expected derivative extension for file set id" do
-      file_set = work.members.find { |m| m.class == FileSet }
+      file_set = work.members.detect { |m| m.is_a? FileSet }
       adapter = described_class.new(file_set.id)
       ext_found = adapter.keys
       expect(ext_found).to include 'txt'

--- a/spec/iiif_print/data/work_file_spec.rb
+++ b/spec/iiif_print/data/work_file_spec.rb
@@ -8,26 +8,26 @@ RSpec.describe IiifPrint::Data::WorkFile do
   let(:work) { work_with_file }
 
   describe "adapter composition" do
-    xit "adapts work with nil fileset" do
+    it "adapts work with nil fileset" do
       adapter = described_class.new(work)
       expect(adapter.work).to be work
       expect(adapter.fileset).to be_nil
     end
 
-    xit "adapts work with 'of' alt constructor" do
+    it "adapts work with 'of' alt constructor" do
       adapter = described_class.of(work)
       expect(adapter.work).to be work
     end
 
-    xit "adapts work and explicitly provided fileset" do
-      fileset = work.members.find { |m| m.class == FileSet }
+    it "adapts work and explicitly provided fileset" do
+      fileset = work.members.detect { |m| m.is_a? FileSet }
       adapter = described_class.of(work, fileset)
       expect(adapter.work).to be work
       expect(adapter.fileset).to be fileset
     end
 
-    xit "constructs with a parent object, if provided" do
-      fileset = work.members.find { |m| m.class == FileSet }
+    it "constructs with a parent object, if provided" do
+      fileset = work.members.detect { |m| m.is_a? FileSet }
       parent = double('parent')
       adapter = described_class.of(work, fileset, parent)
       expect(adapter.parent).to be parent
@@ -35,15 +35,15 @@ RSpec.describe IiifPrint::Data::WorkFile do
   end
 
   describe "read file metadata" do
-    xit "gets original filename" do
-      fileset = work.members.find { |m| m.class == FileSet }
+    it "gets original filename" do
+      fileset = work.members.detect { |m| m.is_a? FileSet }
       adapter = described_class.of(work, fileset)
       expect(adapter.name).to eq fileset.original_file.original_name
       expect(adapter.name).to eq 'credits.md'
     end
 
-    xit "gets miscellaneous metadata field values" do
-      fileset = work.members.find { |m| m.class == FileSet }
+    it "gets miscellaneous metadata field values" do
+      fileset = work.members.detect { |m| m.is_a? FileSet }
       adapter = described_class.of(work, fileset)
       # expectations for accessors of size, date_*, mime_type
       expect(adapter.size).to eq File.size(txt_path)
@@ -57,8 +57,8 @@ RSpec.describe IiifPrint::Data::WorkFile do
   end
 
   describe "read binary via transparent repository checkout" do
-    xit "gets path (from checkout)" do
-      fileset = work.members.find { |m| m.class == FileSet }
+    it "gets path (from checkout)" do
+      fileset = work.members.detect { |m| m.is_a? FileSet }
       adapter = described_class.of(work, fileset)
       # Get a path to a working copy
       path = adapter.path
@@ -68,8 +68,8 @@ RSpec.describe IiifPrint::Data::WorkFile do
       expect(File.size(path)).to eq fileset.original_file.size
     end
 
-    xit "gets data as bytes" do
-      fileset = work.members.find { |m| m.class == FileSet }
+    it "gets data as bytes" do
+      fileset = work.members.detect { |m| m.is_a? FileSet }
       adapter = described_class.of(work, fileset)
       # Get a data from the working copy
       data = adapter.data
@@ -78,16 +78,16 @@ RSpec.describe IiifPrint::Data::WorkFile do
       expect(data.size).to eq fileset.original_file.size
     end
 
-    xit "runs block on data as IO" do
-      fileset = work.members.find { |m| m.class == FileSet }
+    it "runs block on data as IO" do
+      fileset = work.members.detect { |m| m.is_a? FileSet }
       adapter = described_class.of(work, fileset)
       adapter.with_io { |io| expect(io.read.size).to eq File.size(txt_path) }
     end
   end
 
   describe "derivative access" do
-    xit "gets derivatives for file" do
-      fileset = work.members.find { |m| m.class == FileSet }
+    it "gets derivatives for file" do
+      fileset = work.members.detect { |m| m.is_a? FileSet }
       adapter = described_class.of(work, fileset)
       expect(adapter.derivatives.class).to eq \
         IiifPrint::Data::WorkDerivatives

--- a/spec/iiif_print/data/work_files_spec.rb
+++ b/spec/iiif_print/data/work_files_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
       expect(values.size).to eq 1
       expect(values[0]).to be_an IiifPrint::Data::WorkFile
       expect(values[0].parent).to be adapter
-      first_fileset = work.members.find { |m| m.class == FileSet }
+      first_fileset = work.members.detect { |m| m.is_a?(FileSet) }
       expect(values[0].fileset).to eq first_fileset
       expect(values[0].unwrapped).to be_a Hydra::PCDM::File
     end
@@ -77,7 +77,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
       keys = adapter.keys
       expect(keys).to be_an Array
       expect(keys[0]).to be_a String
-      first_fileset = work.members.find { |m| m.class == FileSet }
+      first_fileset = work.members.detect { |m| m.is_a?(FileSet) }
       expect(keys[0]).to eq first_fileset.id
     end
 
@@ -93,7 +93,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
 
     it "gets work file by fileset id" do
       adapter = described_class.of(work)
-      first_fileset = work.members.find { |m| m.class == FileSet }
+      first_fileset = work.members.detect { |m| m.is_a?(FileSet) }
       fsid = adapter.keys[0]
       expect(fsid).to eq first_fileset.id
       work_file = adapter.get(fsid)
@@ -104,7 +104,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
 
     it "gets work file by work-local filename" do
       adapter = described_class.of(work)
-      first_fileset = work.members.find { |m| m.class == FileSet }
+      first_fileset = work.members.detect { |m| m.is_a?(FileSet) }
       name = first_fileset.original_file.original_name
       work_file = adapter.get(name)
       expect(work_file).to eq adapter.get(first_fileset.id)
@@ -168,7 +168,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
       adapter.unassign(adapter.keys[0])
       adapter.commit!
       expect(adapter.keys.size).to eq 0
-      expect(work.members.count { |m| m.class == FileSet }).to eq 0
+      expect(work.members.count { |m| m.is_a? FileSet }).to eq 0
     end
 
     context "when it is a new work" do
@@ -203,7 +203,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
       #   should refresh the work.members, and by consequence adapter.keys
       work.reload
       expect(adapter.keys.size).to eq 1
-      expect(work.members.count { |m| m.class == FileSet }).to eq 1
+      expect(work.members.count { |m| m.is_a? FileSet }).to eq 1
       expect(adapter.names).to include 'ocr_gray.tiff'
     end
 
@@ -212,7 +212,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
       adapter.assign(tiff_path)
       adapter.commit!
       bare_work.reload
-      fileset = bare_work.members.find { |w| w.class == FileSet }
+      fileset = bare_work.members.detect { |m| m.is_a?(FileSet) }
       permission_methods.each do |m|
         expect(fileset.send(m)).to match_array bare_work.send(m)
       end
@@ -222,7 +222,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
 
   describe "derivative access" do
     it "gets derivatives for first fileset" do
-      fileset = work.members.find { |m| m.class == FileSet }
+      fileset = work.members.detect { |m| m.is_a?(FileSet) }
       adapter = described_class.of(work)
       # adapts same context(s):
       expect(adapter.derivatives.fileset.id).to eq fileset.id

--- a/spec/misc_shared.rb
+++ b/spec/misc_shared.rb
@@ -63,7 +63,7 @@ RSpec.shared_context "shared setup", shared_context: :metadata do
   end
 
   def work_file_set(work)
-    work.members.find { |m| m.class == FileSet }
+    work.members.detect { |m| m.is_a? FileSet }
   end
 
   def text_path(work)

--- a/spec/services/iiif_print/pluggable_derivative_service_spec.rb
+++ b/spec/services/iiif_print/pluggable_derivative_service_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe IiifPrint::PluggableDerivativeService do
         end
 
         def jp2_plugin?(plugins)
-          r = plugins.select { |p| p.class == IiifPrint::JP2DerivativeService }
+          r = plugins.select { |p| p.is_a? IiifPrint::JP2DerivativeService }
           !r.empty?
         end
 

--- a/spec/services/iiif_print/text_formats_from_alto_service_spec.rb
+++ b/spec/services/iiif_print/text_formats_from_alto_service_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe IiifPrint::TextFormatsFromALTOService do
       attach_primary_file(work)
       attach_alto(work)
       work.reload
-      file_set = work.ordered_members.to_a.find { |m| m.class == FileSet }
+      file_set = work.ordered_members.to_a.find { |m| m.is_a? FileSet) }
       service = described_class.new(file_set)
       service.create_derivatives('/a/path/here/needed/but/will/not/matter')
       coords = JSON.parse(derivatives_of(work).data('json'))


### PR DESCRIPTION
This commit includes three concepts:

- Shifting from `class ==` to `is_a?` comparison
- Favoring `detect` over `find`
- Removing `xit` for some methods

The `is_a?` comparison allows for inheritance checks.

The `detect` over `find` is because in some of our test models we set
`#members` as an Array and in other work's members are
reflections (e.g. `has_many :members`) from `ActiveFedora::Base`.

Below is the keying error for the problem:

```shell
Failure/Error: first_fileset = work.members.find { |m| m.class == FileSet }

RuntimeError:
  Couldn't find reflection
```

Removing `xit` follows on the work for favoring `detect`
