### PR TITLE
Removing parser ambiguity

### DIFF
--- a/lib/iiif_print/data/work_files.rb
+++ b/lib/iiif_print/data/work_files.rb
@@ -153,7 +153,7 @@ module IiifPrint
 
       def filesets
         # file sets with non-nil original file contained:
-        work.members.select { |m| m.is_a? FileSet && m.original_file }
+        work.members.select { |m| m.is_a?(FileSet) && m.original_file }
       end
 
       def user

--- a/spec/iiif_print/data/work_files_spec.rb
+++ b/spec/iiif_print/data/work_files_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
       adapter.unassign(adapter.keys[0])
       adapter.commit!
       expect(adapter.keys.size).to eq 0
-      expect(work.members.count { |m| m.is_a? FileSet }).to eq 0
+      expect(work.members.to_a.count { |m| m.is_a? FileSet }).to eq 0
     end
 
     context "when it is a new work" do
@@ -203,7 +203,7 @@ RSpec.describe IiifPrint::Data::WorkFiles do
       #   should refresh the work.members, and by consequence adapter.keys
       work.reload
       expect(adapter.keys.size).to eq 1
-      expect(work.members.count { |m| m.is_a? FileSet }).to eq 1
+      expect(work.members.to_a.count { |m| m.is_a? FileSet }).to eq 1
       expect(adapter.names).to include 'ocr_gray.tiff'
     end
 

--- a/spec/services/iiif_print/text_formats_from_alto_service_spec.rb
+++ b/spec/services/iiif_print/text_formats_from_alto_service_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe IiifPrint::TextFormatsFromALTOService do
       attach_primary_file(work)
       attach_alto(work)
       work.reload
-      file_set = work.ordered_members.to_a.find { |m| m.is_a? FileSet) }
+      file_set = work.ordered_members.to_a.find { |m| m.is_a? FileSet }
       service = described_class.new(file_set)
       service.create_derivatives('/a/path/here/needed/but/will/not/matter')
       coords = JSON.parse(derivatives_of(work).data('json'))


### PR DESCRIPTION
There are three things in this change:

1. Putting parentheses around a method call; the parser was confused by this.
2. Casting a reflection into an array (sometimes these are arrays sometimes reflections);  must be related to randomized specs.
3. Removing a trailing `)` that was causing a parse error.