### PR TITLE
Fixing broken spec

### DIFF
--- a/spec/iiif_print/catalog_search_builder_spec.rb
+++ b/spec/iiif_print/catalog_search_builder_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-RSpec.describe CustomSearchBuilder do
+
+RSpec.describe IiifPrint::CatalogSearchBuilder do
   # specs for IiifPrint::HighlightSearchParams
   describe 'highlight_search_params' do
     let(:solr_parameters) { { q: 'abolition' } }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,13 @@ RSpec.configure do |config|
     require 'active_fedora/cleaner'
     require 'database_cleaner'
 
+    # By default, Hyrax uses a database minter class.  That's the preferred pathway (because you are
+    # tracking minting state in the database).  However, for testing purposes we don't need to / nor
+    # want to install the minter migrations.  Hence we're favoring this approach.
+    minter_class = ::Noid::Rails::Minter::File
+    ::Noid::Rails.config.minter_class = minter_class
+    Hyrax.config.noid_minter_class = minter_class
+
     ActiveFedora::Cleaner.clean!
     DatabaseCleaner.clean_with(:truncation)
 


### PR DESCRIPTION
## Moving spec and renaming

de329cee9d24561204e4eafe4a855551e1254694

During a refactoring, I failed to move the spec to the right directory.

## Configuring specs to use file system noid minting

847a26d29afd4c0cc143aee879080c3a4c0b119e

Prior to this commit, we leveraged Hyrax's default noid minting
approach.  It appears that that changed from file based state tracking
to database state tracking.

This created a problem when rebuilding the internal application.  Namely
I encountered the following exception:

```
ActiveRecord::StatementInvalid:
        Could not find table 'minter_states'
```

The option was to either:

1. run the noids-rails generator for the migrations as part of the
   engine cart/install process...
2. set the noids minter class to be the file system.

I have chosen the latter; it's not something I'd want to do for
production but for tests, I'd rather not run another round of
generators.
