### PR TITLE
Adding version enforcement for Bulkrax

### DIFF
--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -12,6 +12,17 @@ module IiifPrint
 
     # rubocop:disable Metrics/BlockLength
     config.to_prepare do
+      # We don't have a hard requirement of Bullkrax but in our experience, lingering on earlier
+      # versions can introduce bugs of both Bulkrax and some of the assumptions that we've resolved.
+      if defined?(Bulkrax) && !ENV.fetch("SKIP_IIIF_PRINT_BULKRAX_VERSION_REQUIREMENT", false)
+        if Bulkrax::VERSION.to_i < 5
+          raise "IiifPrint does not have a hard dependency on Bulkrax, " \
+                "but if you have Bulkrax installed we recommend at least version 5.0.0.  " \
+                "To ignore this recommendation please add SKIP_IIIF_PRINT_BULKRAX_VERSION_REQUIREMENT " \
+                "to your ENV variables."
+        end
+      end
+
       # Inject PluggableDerivativeService ahead of Hyrax default.
       #   This wraps Hyrax default, but allows multiple valid services
       #   to be configured, instead of just the _first_ valid service.


### PR DESCRIPTION
With this commit, if the downstream application has Bulkrax we strongly encourage the Bulkrax version upgrade; though do provide a means of avoiding our strong recommendation.