### PR TITLE
[hotfix] add a require statement to the engine so that we have access to bulkrax version

### DIFF
--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -1,6 +1,7 @@
 require 'active_fedora'
 require 'hyrax'
 require 'blacklight_iiif_search'
+require "bulkrax/version"
 
 module IiifPrint
   # module constants:
@@ -15,6 +16,7 @@ module IiifPrint
       # We don't have a hard requirement of Bullkrax but in our experience, lingering on earlier
       # versions can introduce bugs of both Bulkrax and some of the assumptions that we've resolved.
       if defined?(Bulkrax) && !ENV.fetch("SKIP_IIIF_PRINT_BULKRAX_VERSION_REQUIREMENT", false)
+        byebug
         if Bulkrax::VERSION.to_i < 5
           raise "IiifPrint does not have a hard dependency on Bulkrax, " \
                 "but if you have Bulkrax installed we recommend at least version 5.0.0.  " \

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -16,7 +16,6 @@ module IiifPrint
       # We don't have a hard requirement of Bullkrax but in our experience, lingering on earlier
       # versions can introduce bugs of both Bulkrax and some of the assumptions that we've resolved.
       if defined?(Bulkrax) && !ENV.fetch("SKIP_IIIF_PRINT_BULKRAX_VERSION_REQUIREMENT", false)
-        byebug
         if Bulkrax::VERSION.to_i < 5
           raise "IiifPrint does not have a hard dependency on Bulkrax, " \
                 "but if you have Bulkrax installed we recommend at least version 5.0.0.  " \


### PR DESCRIPTION
When install this gem on a hyku main, we received the following error when trying to spin up the app. 

`*** NameError Exception: uninitialized constant Bulkrax::VERSION`

Per the changes seen in [this PR.](https://github.com/scientist-softserv/iiif_print/commit/9b5c568a5ec951e9dd1d29b75dacc3c92e8eb754)

To resolve this, I added

`require "bulkrax/version"`

to the top of the file. 
