### PR TITLE
update readme to enable iiifprint catalog search builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,6 @@ IiifPrint easily integrates with your Hyrax 2.x applications.
 * Run `rails generate iiif_print:install`
 * Set config options as indicated below...
 
-TO ENABLE OCR Search (from the UV and catalog search)
-* In the CatalogController, find the add_search_field config block for 'all_fields'. Add advanced_parse: false, as seen in the following example:
-```rb
-    config.add_search_field('all_fields', label: 'All Fields', include_in_advanced_search: false, advanced_parse: false) do |field|
-      all_names = config.show_fields.values.map(&:field).join(" ")
-      title_name = 'title_tesim'
-      field.solr_parameters = {
-        qf: "#{all_names} file_format_tesim all_text_tsimv",
-        pf: title_name.to_s
-      }
-    end
-```
-* Additionally, find and replace all instances of all_text_timv with all_text_tsimv, in the CatalogController.
 
 ## Changes made by the installer:
 * In `app/assets/javascripts/application.js`, it adds `//= require iiif_print`
@@ -145,6 +132,22 @@ IiifPrint.config do |config|
   config.sort_iiif_manifest_canvases_by = :date_published
 end
 ```
+
+TO ENABLE OCR Search (from the UV and catalog search)
+### catalog_controller.rb
+* In the CatalogController, find the add_search_field config block for 'all_fields'. Add advanced_parse: false, as seen in the following example:
+```rb
+    config.add_search_field('all_fields', label: 'All Fields', include_in_advanced_search: false, advanced_parse: false) do |field|
+      all_names = config.show_fields.values.map(&:field).join(" ")
+      title_name = 'title_tesim'
+      field.solr_parameters = {
+        qf: "#{all_names} file_format_tesim all_text_tsimv",
+        pf: title_name.to_s
+      }
+    end
+```
+* Additionally, find and replace all instances of all_text_timv with all_text_tsimv, in the CatalogController.
+* Set config.search_builder_class = IiifPrint::CatalogSearchBuilder
 
 # Ingesting Content
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ TO ENABLE OCR Search (from the UV and catalog search)
       }
     end
 ```
-* Additionally, find and replace all instances of all_text_timv with all_text_tsimv, in the CatalogController.
+* Additionally, find and replace all instances of all_text_timv with all_text_tsimv.
 * Set config.search_builder_class = IiifPrint::CatalogSearchBuilder
 
 # Ingesting Content


### PR DESCRIPTION
Add instructions to enable IiifPrint::CatalogSearchBuilder. 

This is needed to return parents only, when searching the catalog controller. 