### PR TITLE
move decorate statement into after inititalize block

### DIFF
--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -24,7 +24,6 @@ module IiifPrint
         end
       end
 
-
       # Inject PluggableDerivativeService ahead of Hyrax default.
       #   This wraps Hyrax default, but allows multiple valid services
       #   to be configured, instead of just the _first_ valid service.

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -24,6 +24,7 @@ module IiifPrint
         end
       end
 
+
       # Inject PluggableDerivativeService ahead of Hyrax default.
       #   This wraps Hyrax default, but allows multiple valid services
       #   to be configured, instead of just the _first_ valid service.
@@ -44,7 +45,6 @@ module IiifPrint
 
       IiifPrint::ChildIndexer.decorate_work_types!
       IiifPrint::FileSetIndexer.decorate(Hyrax::FileSetIndexer)
-      IiifPrint::Solr::Document.decorate(SolrDocument)
 
       ::BlacklightIiifSearch::IiifSearchResponse.prepend(IiifPrint::IiifSearchResponseDecorator)
       ::BlacklightIiifSearch::IiifSearchAnnotation.prepend(IiifPrint::BlacklightIiifSearch::AnnotationDecorator)
@@ -68,6 +68,10 @@ module IiifPrint
           IiifPrint.config.handle_after_create_fileset(file_set, user)
         end
       end
+    end
+
+    config.after_initialize do
+      IiifPrint::Solr::Document.decorate(SolrDocument)
     end
     # rubocop:enable Metrics/BlockLength
   end


### PR DESCRIPTION
On hyku, a load issue was discovered once iiif_print was installed which caused missing translations. 

We traced it back to this decorate statement and moved it into an after_initialized block. After doing so, the local files were correctly listed in the I8n.load_path, as expected. 