### PR TITLE
removing because as stated it only applies to the first account

### DIFF
--- a/app/indexers/concerns/iiif_print/child_indexer.rb
+++ b/app/indexers/concerns/iiif_print/child_indexer.rb
@@ -11,8 +11,6 @@ module IiifPrint
       # TODO: This method is in the wrong location; says indexing but there's also the SetChildFlag
       # consideration.  Consider refactoring this stuff into a single nested module.
       #
-      # Because we might be in Hyku
-      switch!(Account.first) if defined? Account
 
       Hyrax.config.curation_concerns.each do |work_type|
         work_type.send(:include, IiifPrint::SetChildFlag) unless work_type.included_modules.include?(IiifPrint::SetChildFlag)


### PR DESCRIPTION
the ADL pipeline issue traced back to the changes of this PR. 

The switch statement may not even be necessary because as implemented, it only applies to 1 account. What about the others? 

Removing it for now and with the assumption that it will apply to all work types by default( -> I'll test this on Adventist) 

For allinson flex apps we may need to bring it back but it will need to loop through all of the accounts, not just grab the first one. 