### PR TITLE
Enabling greater tesseract configurability

### DIFF
--- a/app/services/iiif_print/pluggable_derivative_service.rb
+++ b/app/services/iiif_print/pluggable_derivative_service.rb
@@ -101,9 +101,20 @@ class IiifPrint::PluggableDerivativeService
     )
   end
 
+  # This method is responsible for determine what are the possible plugins / services that this file
+  # set would use.  That "possibility" is based on the work.  Later, we will check the plugin's
+  # "valid?" which would now look at the specific file_set for validity.
   def plugins_for(file_set)
-    return Array(default_plugins) unless file_set.parent.try(:iiif_print_config?)
+    parent = parent_for(file_set)
+    return Array(default_plugins) if parent.nil?
+    return Array(default_plugins) unless parent.respond_to?(:iiif_print_config)
 
     (file_set.parent.iiif_print_config.derivative_service_plugins + Array(default_plugins)).flatten.compact.uniq
+  end
+
+  def parent_for(file_set)
+    # fallback to Fedora-stored relationships if work's aggregation of
+    #   file set is not indexed in Solr
+    file_set.parent || file_set.member_of.find(&:work?)
   end
 end

--- a/lib/iiif_print/base_derivative_service.rb
+++ b/lib/iiif_print/base_derivative_service.rb
@@ -13,12 +13,19 @@ module IiifPrint
       @source_meta = nil
     end
 
+    ##
+    # We assume that for the file set's parent that this is an acceptable plugin.  Now, we ask for
+    # this specific file_set is it valid.  For example, we would not attempt to extract text from a
+    # movie even though the parent work says to attempt to extract text on any attached file sets.
+    # Put another way, we can upload a PDF or a Movie to the parent.
+    #
+    # In subclass, you'll want to consider the attributes of the file_set and whether that subclass
+    # should process the given file_set.
+    #
+    # @see IiifPrint::PluggableDerivativeService#plugins_for
+    # @return [Boolean]
     def valid?
-      parent = file_set.in_works[0]
-      # fallback to Fedora-stored relationships if work's aggregation of
-      #   file set is not indexed in Solr
-      parent = file_set.member_of.find(&:work?) if parent.nil?
-      parent.try(:iiif_print_config?)
+      true
     end
 
     def derivative_path_factory

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -85,5 +85,15 @@ module IiifPrint
     def sort_iiif_manifest_canvases_by
       @sort_iiif_manifest_canvases_by || :title
     end
+
+    attr_writer :additional_tessearct_options
+    ##
+    # The additional options to pass to the Tesseract configuration
+    #
+    # @see https://tesseract-ocr.github.io/tessdoc/Command-Line-Usage.html
+    # @return [String]
+    def additional_tessearct_options
+      @additional_tessearct_options || ""
+    end
   end
 end

--- a/lib/iiif_print/text_extraction/page_ocr.rb
+++ b/lib/iiif_print/text_extraction/page_ocr.rb
@@ -9,7 +9,7 @@ module IiifPrint
     class PageOCR
       attr_accessor :html, :path
 
-      def initialize(path)
+      def initialize(path, additional_tessearct_options: IiifPrint.config.additional_tessearct_options)
         @path = path
         # hOCR html:
         @html = nil
@@ -17,11 +17,13 @@ module IiifPrint
         @source_meta = nil
         @box = nil
         @plain = nil
+        @additional_tessearct_options = additional_tessearct_options
       end
 
       def run_ocr
         outfile = File.join(Dir.mktmpdir, 'output_html')
         cmd = "tesseract #{path} #{outfile} hocr"
+        cmd += " #{@additional_tessearct_options}" if @additional_tessearct_options.present?
         `#{cmd}`
         outfile + '.hocr'
       end

--- a/spec/iiif_print/base_derivative_service_spec.rb
+++ b/spec/iiif_print/base_derivative_service_spec.rb
@@ -2,20 +2,10 @@ require 'spec_helper'
 
 RSpec.describe IiifPrint::BaseDerivativeService do
   describe '#valid?' do
-    subject(:service) { described_class.new(file_set) }
+    let(:file_set) { double(FileSet) }
+    let(:service) { described_class.new(file_set) }
+    subject { service.valid? }
 
-    context 'when parent is iiif_print configured' do
-      let(:file_set) { double(FileSet, in_works: [work]) }
-      let(:work) { WorkWithIiifPrintConfig.new }
-
-      it { is_expected.to be_valid }
-    end
-
-    context 'when parent is not iiif_print configured' do
-      let(:file_set) { double(FileSet, in_works: [work]) }
-      let(:work) { WorkWithOutConfig.new }
-
-      it { is_expected.not_to be_valid }
-    end
+    it { is_expected.to be_truthy }
   end
 end

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe IiifPrint::Configuration do
   end
 
   describe '#additional_tessearct_options' do
-
     context "by default" do
       subject { config.additional_tessearct_options }
       it { is_expected.not_to be_present }
@@ -61,8 +60,8 @@ RSpec.describe IiifPrint::Configuration do
       expect do
         config.additional_tessearct_options = "-l esperanto"
       end.to change(config, :additional_tessearct_options)
-               .from("")
-               .to("-l esperanto")
+        .from("")
+        .to("-l esperanto")
     end
   end
 end

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -49,4 +49,20 @@ RSpec.describe IiifPrint::Configuration do
       end
     end
   end
+
+  describe '#additional_tessearct_options' do
+
+    context "by default" do
+      subject { config.additional_tessearct_options }
+      it { is_expected.not_to be_present }
+    end
+
+    it "can be configured" do
+      expect do
+        config.additional_tessearct_options = "-l esperanto"
+      end.to change(config, :additional_tessearct_options)
+               .from("")
+               .to("-l esperanto")
+    end
+  end
 end

--- a/spec/iiif_print/jobs/child_works_from_pdf_job_spec.rb
+++ b/spec/iiif_print/jobs/child_works_from_pdf_job_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'misc_shared'
 
-RSpec.describe IiifPrint::Actors::IiifPrintUploadActor do
+RSpec.describe IiifPrint::Jobs::ChildWorksFromPdfJob do
   # TODO: add specs
   let(:work) { WorkWithIiifPrintConfig.new(title: ['required title']) }
   let(:my_user) { build(:user) }

--- a/spec/iiif_print/jobs/create_relationships_job_spec.rb
+++ b/spec/iiif_print/jobs/create_relationships_job_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'misc_shared'
 
-RSpec.describe IiifPrint::Actors::IiifPrintUploadActor do
+RSpec.describe IiifPrint::Jobs::CreateRelationshipsJob do
   # TODO: add specs
   let(:parent) { WorkWithIiifPrintConfig.new(title: ['required title']) }
   let(:my_user) { build(:user) }

--- a/spec/indexers/concerns/iiif_print/indexes_full_text_spec.rb
+++ b/spec/indexers/concerns/iiif_print/indexes_full_text_spec.rb
@@ -1,8 +1,0 @@
-require 'spec_helper'
-require 'misc_shared'
-
-RSpec.describe IiifPrint::IndexesFullText do
-  describe "#index_full_text" do
-    xit "needs specs"
-  end
-end

--- a/spec/services/iiif_print/pluggable_derivative_service_spec.rb
+++ b/spec/services/iiif_print/pluggable_derivative_service_spec.rb
@@ -26,7 +26,11 @@ RSpec.describe IiifPrint::PluggableDerivativeService do
     end
 
     it "is the first valid service found" do
-      found = Hyrax::DerivativeService.for(FileSet.new)
+      file_set = double(FileSet,
+                        class: FileSet,
+                        mime_type: 'application/pdf',
+                        parent: MyIiifConfiguredWorkWithAllDerivativeServices.new)
+      found = Hyrax::DerivativeService.for(file_set)
       expect(found).to be_a described_class
     end
   end
@@ -40,7 +44,10 @@ RSpec.describe IiifPrint::PluggableDerivativeService do
 
     describe "#plugins" do
       it "uses the default derivatives service" do
-        file_set = double(FileSet, parent: MyWork.new)
+        file_set = double(FileSet,
+                          class: FileSet,
+                          mime_type: 'application/pdf',
+                          parent: MyWork.new)
         service = described_class.new(file_set)
         expect(service.plugins).to eq [Hyrax::FileSetDerivativesService]
       end


### PR DESCRIPTION
## Applying some broken spec hygene

3f557f7b260202d9115584ba677219470073afc9

There were a few failing specs around constants not existing.  This
commit addreses those failures.

## Adjusting valid plugin testing

06bdcf9db23ea853a58b7b01a1ba7ebb6a30fddf

Prior to this commit, we were twice checking a file set's parent.  First
in the `Bulkrax::PluggableDerivativeService#plugins_for` methdod and
then immediately in the `Bulkrax::BaseDerivativeService.rb`.

With this commit, we're not repeating that logic.  Instead we're using
the plugins_for method to determine what are the possible valid plugins
for the file_set's parent.  And then we want to again answer what
derivative service is valid for the file set.

## Exposing configuration for tesseract options

32c01d9197aacde0f9d425b58c2df0f77b54322e

Prior to this commit, we had a fully hard-coded tesseract command
invocation.

With this commit, we can provide additional options (e.g. different
dictionaries or languages, as well as other tesseract options).
