### PR TITLE
Change an index key from `Integer` to `String`

### DIFF
--- a/lib/iiif_print/jobs/create_relationships_job.rb
+++ b/lib/iiif_print/jobs/create_relationships_job.rb
@@ -61,7 +61,7 @@ module IiifPrint
       def create_relationships(user:, parent:, ordered_children:)
         records_hash = {}
         ordered_children.map(&:id).each_with_index do |child_id, i|
-          records_hash[i] = { id: child_id }
+          records_hash[i.to_s] = { id: child_id }
         end
         attrs = { work_members_attributes: records_hash }
         parent.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)


### PR DESCRIPTION
In Essi, because the index was an interger, it was causing the `CreateRelationshipsJob` to crash.

Error from Sidekiq:
ActiveJob::SerializationError: Only string and symbol hash keys may be serialized as job arguments, but 0 is a Integer

Observed on Sidekiq v6.5.7