### PR TITLE
Skip blacklight_iiif_search:install solr changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,6 @@ IiifPrint easily integrates with your Hyrax 2.x applications.
 * In `config/routes.rb`, it adds `concerns :iiif_search` in the `resources :solr_documents` block
 * Adds `config/initializers/iiif_print.rb`
 * Adds three migrations, `CreateIiifPrintDerivativeAttachments`, `CreateIiifPrintIngestFileRelations`, and `CreateIiifPrintPendingRelationships`
-* In `solr/conf/schema.xml`, it adds Blacklight IIIF Search autocomplete config
-* In `solr/conf/solrconfig.xml`, it adds Blacklight IIIF Search autocomplete config
-* Adds `solr/lib/solr-tokenizing_suggester-7.x.jar`
 
 (It may be helpful to run `git diff` after installation to see all the changes made by the installer.)
 
@@ -146,7 +143,7 @@ TO ENABLE OCR Search (from the UV and catalog search)
       }
     end
 ```
-* Set `config.search_builder_class = IiifPrint::CatalogSearchBuilder` to remove works from the catalog search results if `is_child_bsi: true` 
+* Set `config.search_builder_class = IiifPrint::CatalogSearchBuilder` to remove works from the catalog search results if `is_child_bsi: true`
 * Ensure that all text search is configured in default_solr_params config block:
 ```rb
     config.default_solr_params = {

--- a/lib/generators/iiif_print/install_generator.rb
+++ b/lib/generators/iiif_print/install_generator.rb
@@ -15,7 +15,7 @@ module IiifPrint
       say_status('info',
                  'BLACKLIGHT IIIF SEARCH NOT INSTALLED; INSTALLING BLACKLIGHT IIIF SEARCH',
                  :blue)
-      generate 'blacklight_iiif_search:install'
+      generate 'blacklight_iiif_search:install --skip-solr'
     end
 
     def catalog_controller_configuration


### PR DESCRIPTION
The [`BlacklightIiifSearch::InstallGenerator`][1] allows for skipping installing the SOLR changes.  See below:

```ruby
def add_solr_config
  generate 'blacklight_iiif_search:solr' unless options[:'skip-solr']
end
```

With this commit, we'll skip over those changes.  The application will still have the the suggest routes and configuration; which may need further investigation: Is the Universal Viewer making requests that are silently failing?  Do we need the catalog controller configuration?

This all is very challenging to test without a full install.

The attached file (excluding the `vendor/plugins`) shows what changes will be made to British Library when we run an install using this change:

<img width="835" alt="blacklight_iiif_search_generator_results_for_modification" src="https://user-images.githubusercontent.com/2130/223262322-2704b45c-a7b4-4719-af99-9758e72a343c.png">

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/147

[1]: https://github.com/boston-library/blacklight_iiif_search/blob/b2fc5abdb3027762a249dcba9afb8998c6da8ffe/lib/generators/blacklight_iiif_search/install_generator.rb#L43-L45