### PR TITLE
i160 - set up label requirement for PRs and set first release version

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -1,0 +1,24 @@
+name: Verify
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - master
+
+jobs:
+  branches:
+    runs-on: ubuntu-latest
+    name: Disallow "master" branch name
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check branch names
+        run: |
+          git fetch --all --quiet --prune --prune-tags
+          if [[ -n "$(git branch --all --list master */master)" ]]; then
+            echo "A branch named 'master' was found. Please remove it."
+            echo "$(git branch --all --list master */master)"
+          fi
+          [[ -z "$(git branch --all --list master */master)" ]]

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -1,0 +1,25 @@
+name: Verify
+on:
+  pull_request:
+    branches:
+      - '**'
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  check_pr_labels:
+    runs-on: ubuntu-latest
+    name: PR has required labels
+    steps:
+      - uses: actions/checkout@v2
+
+      # https://github.com/marketplace/actions/label-checker-for-pull-requests
+      - name: Check PR for Release Notes labels
+        uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: patch-ver,minor-ver,major-ver,ignore-for-release
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/iiif_print/version.rb
+++ b/lib/iiif_print/version.rb
@@ -1,3 +1,3 @@
 module IiifPrint
-  VERSION = '0.0.1'.freeze
+  VERSION = '1.0.0'.freeze
 end


### PR DESCRIPTION
This PR pulls over the same set up that bulkrax requires (a check that PRs have release-note labels on them before we're able to merge). This will help us when auto generating release notes. 

Additionally we are setting the first release version to v1.0.0