### PR TITLE
Adding Pages to PNGs splitter

### DIFF
--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -18,7 +18,7 @@ require "iiif_print/jobs/application_job"
 require "iiif_print/blacklight_iiif_search/annotation_decorator"
 require "iiif_print/jobs/child_works_from_pdf_job"
 require "iiif_print/jobs/create_relationships_job"
-require "iiif_print/split_pdfs/pages_into_images_service"
+require "iiif_print/split_pdfs/base_splitter"
 require "iiif_print/split_pdfs/child_work_creation_from_pdf_service"
 
 module IiifPrint
@@ -42,7 +42,7 @@ module IiifPrint
   DEFAULT_MODEL_CONFIGURATION = {
     # Split a PDF into individual page images and create a new child work for each image.
     pdf_splitter_job: IiifPrint::Jobs::ChildWorksFromPdfJob,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesIntoImagesService,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToTiffsSplitter,
     derivative_service_plugins: [
       IiifPrint::JP2DerivativeService,
       IiifPrint::PDFDerivativeService,

--- a/lib/iiif_print/split_pdfs/base_splitter.rb
+++ b/lib/iiif_print/split_pdfs/base_splitter.rb
@@ -12,14 +12,13 @@ module IiifPrint
     # @see #each
     class BaseSplitter
       class_attribute :image_extension
+      class_attribute :compression, default: nil
 
-      DEFAULT_COMPRESSION = 'lzw'.freeze
-      def initialize(path, compression: DEFAULT_COMPRESSION, tmpdir: Dir.mktmpdir, default_dpi: 400)
+      def initialize(path, tmpdir: Dir.mktmpdir, default_dpi: 400)
         @baseid = SecureRandom.uuid
         @pdfpath = path
         @pdfinfo = IiifPrint::SplitPdfs::PdfImageExtractionService.new(@pdfpath)
         @tmpdir = tmpdir
-        @compression = compression
         @default_dpi = default_dpi
       end
 
@@ -60,9 +59,9 @@ module IiifPrint
         output_base = File.join(tmpdir, "#{baseid}-page%d.#{image_extension}")
         # NOTE: you must call gsdevice before compression, as compression is
         # updated during the gsdevice call.
-        cmd = "gs -dNOPAUSE -dBATCH -sDEVICE=#{gsdevice} " \
-              "-dTextAlphaBits=4 -sCompression=#{compression} " \
-              "-sOutputFile=#{output_base} -r#{ppi} -f #{pdfpath}"
+        cmd = "gs -dNOPAUSE -dBATCH -sDEVICE=#{gsdevice} -dTextAlphaBits=4"
+        cmd += " -sCompression=#{compression}" if compression?
+        cmd += " -sOutputFile=#{output_base} -r#{ppi} -f #{pdfpath}"
         filenames = []
 
         Open3.popen3(cmd) do |_stdin, stdout, _stderr, _wait_thr|

--- a/lib/iiif_print/split_pdfs/base_splitter.rb
+++ b/lib/iiif_print/split_pdfs/base_splitter.rb
@@ -5,10 +5,14 @@ require 'iiif_print/split_pdfs/pdf_image_extraction_service'
 
 module IiifPrint
   module SplitPdfs
-    # The purpose of this class is to split the PDF into constituent TIFF files.
+    # @abstract
+    #
+    # The purpose of this class is to split the PDF into constituent image files.
     #
     # @see #each
-    class PagesIntoImagesService
+    class BaseSplitter
+      class_attribute :image_extension
+
       DEFAULT_COMPRESSION = 'lzw'.freeze
       def initialize(path, compression: DEFAULT_COMPRESSION, tmpdir: Dir.mktmpdir, default_dpi: 400)
         @baseid = SecureRandom.uuid
@@ -39,8 +43,8 @@ module IiifPrint
         false
       end
 
-      attr_reader :pdfinfo, :tmpdir, :baseid, :compression, :default_dpi, :pdfpath
-      private :pdfinfo, :tmpdir, :baseid, :compression, :default_dpi, :pdfpath
+      attr_reader :pdfinfo, :tmpdir, :baseid, :compression, :default_dpi
+      private :pdfinfo, :tmpdir, :baseid, :compression, :default_dpi
 
       private
 
@@ -53,7 +57,7 @@ module IiifPrint
 
       # ghostscript convert all pages to TIFF
       def gsconvert
-        output_base = File.join(tmpdir, "#{baseid}-page%d.tiff")
+        output_base = File.join(tmpdir, "#{baseid}-page%d.#{image_extension}")
         # NOTE: you must call gsdevice before compression, as compression is
         # updated during the gsdevice call.
         cmd = "gs -dNOPAUSE -dBATCH -sDEVICE=#{gsdevice} " \
@@ -67,7 +71,7 @@ module IiifPrint
             next unless line.start_with?('Page ')
 
             page_number += 1
-            filenames << File.join(tmpdir, "#{baseid}-page#{page_number}.tiff")
+            filenames << File.join(tmpdir, "#{baseid}-page#{page_number}.#{image_extension}")
           end
         end
 
@@ -75,30 +79,7 @@ module IiifPrint
       end
 
       def gsdevice
-        color, channels, bpc = pdfinfo.color
-        device = nil
-        if color == 'gray'
-          # CCITT Group 4 Black and White, if applicable:
-          if bpc == 1
-            device = 'tiffg4'
-            @compression = 'g4'
-          elsif bpc > 1
-            # 8 Bit Grayscale, if applicable:
-            device = 'tiffgray'
-          end
-        end
-
-        # otherwise color:
-        device = colordevice(channels, bpc) if device.nil?
-        device
-      end
-
-      def colordevice(channels, bpc)
-        bits = bpc * channels
-        # will be either 8bpc/16bpd color TIFF,
-        #   with any CMYK source transformed to 8bpc RBG
-        bits = 24 unless [24, 48].include? bits
-        "tiff#{bits}nc"
+        raise NotImplementedError
       end
 
       PAGE_COUNT_REGEXP = %r{^Pages: +(\d+)$}.freeze
@@ -136,3 +117,6 @@ module IiifPrint
     end
   end
 end
+
+require "iiif_print/split_pdfs/pages_to_pngs_splitter"
+require "iiif_print/split_pdfs/pages_to_tiffs_splitter"

--- a/lib/iiif_print/split_pdfs/pages_to_pngs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/pages_to_pngs_splitter.rb
@@ -1,0 +1,26 @@
+module IiifPrint
+  module SplitPdfs
+    # @abstract
+    #
+    # The purpose of this class is to split the PDF into constituent png files.
+    #
+    # @see #each
+    class PagesToPngsSplitter < BaseSplitter
+      self.image_extension = 'png'
+
+      private
+
+      def gsdevice
+        color, _channels, bpc = pdfinfo.color
+        device = nil
+        # 1 Bit Grayscale, if applicable:
+        device = 'pngmonod' if color == 'gray' && bpc == 1
+        # 8 Bit Grayscale, if applicable:
+        device = 'pnggray' if color == 'gray' && bpc > 1
+        # otherwise 24 Bit RGB:
+        device = 'png16m' if device.nil?
+        device
+      end
+    end
+  end
+end

--- a/lib/iiif_print/split_pdfs/pages_to_tiffs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/pages_to_tiffs_splitter.rb
@@ -5,6 +5,8 @@ module IiifPrint
     # @see #each
     class PagesToTiffsSplitter < BaseSplitter
       self.image_extension = 'tiff'
+      DEFAULT_COMPRESSION = 'lzw'.freeze
+      self.compression = DEFAULT_COMPRESSION
 
       private
 
@@ -15,7 +17,7 @@ module IiifPrint
           # CCITT Group 4 Black and White, if applicable:
           if bpc == 1
             device = 'tiffg4'
-            @compression = 'g4'
+            self.compression = 'g4'
           elsif bpc > 1
             # 8 Bit Grayscale, if applicable:
             device = 'tiffgray'

--- a/lib/iiif_print/split_pdfs/pages_to_tiffs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/pages_to_tiffs_splitter.rb
@@ -1,0 +1,39 @@
+module IiifPrint
+  module SplitPdfs
+    # The purpose of this class is to split the PDF into constituent TIFF files.
+    #
+    # @see #each
+    class PagesToTiffsSplitter < BaseSplitter
+      self.image_extension = 'tiff'
+
+      private
+
+      def gsdevice
+        color, channels, bpc = pdfinfo.color
+        device = nil
+        if color == 'gray'
+          # CCITT Group 4 Black and White, if applicable:
+          if bpc == 1
+            device = 'tiffg4'
+            @compression = 'g4'
+          elsif bpc > 1
+            # 8 Bit Grayscale, if applicable:
+            device = 'tiffgray'
+          end
+        end
+
+        # otherwise color:
+        device = colordevice(channels, bpc) if device.nil?
+        device
+      end
+
+      def colordevice(channels, bpc)
+        bits = bpc * channels
+        # will be either 8bpc/16bpd color TIFF,
+        #   with any CMYK source transformed to 8bpc RBG
+        bits = 24 unless [24, 48].include? bits
+        "tiff#{bits}nc"
+      end
+    end
+  end
+end

--- a/spec/iiif_print/split_pdfs/pages_to_pngs_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/pages_to_pngs_splitter_spec.rb
@@ -1,19 +1,18 @@
 require 'spec_helper'
-require 'misc_shared'
 
-RSpec.describe IiifPrint::SplitPdfs::PagesToTiffsSplitter do
+RSpec.describe IiifPrint::SplitPdfs::PagesToPngsSplitter do
   describe '.compression' do
     subject { described_class.compression }
-    it { is_expected.to eq(described_class::DEFAULT_COMPRESSION) }
+    it { is_expected.to be_nil }
   end
 
   describe '.compression?' do
     subject { described_class.compression? }
-    it { is_expected.to be_truthy }
+    it { is_expected.to be_falsey }
   end
 
   describe '.image_extension' do
     subject { described_class.image_extension }
-    it { is_expected.to eq('tiff') }
+    it { is_expected.to eq('png') }
   end
 end

--- a/spec/iiif_print/split_pdfs/pages_to_tiffs_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/pages_to_tiffs_splitter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 require 'misc_shared'
 
-RSpec.describe IiifPrint::SplitPdfs::PagesIntoImagesService do
+RSpec.describe IiifPrint::SplitPdfs::PagesToTiffsSplitter do
   # TODO: add specs
 end

--- a/spec/iiif_print_spec.rb
+++ b/spec/iiif_print_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe IiifPrint do
       end
 
       it "has a #pdf_splitter_service" do
-        expect(record.iiif_print_config.pdf_splitter_service).to be(IiifPrint::SplitPdfs::PagesToTiffsService)
+        expect(record.iiif_print_config.pdf_splitter_service).to be(IiifPrint::SplitPdfs::PagesToTiffsSplitter)
       end
 
       it "has #derivative_service_plugins" do

--- a/spec/iiif_print_spec.rb
+++ b/spec/iiif_print_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe IiifPrint do
       end
 
       it "has a #pdf_splitter_service" do
-        expect(record.iiif_print_config.pdf_splitter_service).to be(IiifPrint::SplitPdfs::PagesIntoImagesService)
+        expect(record.iiif_print_config.pdf_splitter_service).to be(IiifPrint::SplitPdfs::PagesToTiffsService)
       end
 
       it "has #derivative_service_plugins" do


### PR DESCRIPTION
## Adding Pages to PNGs splitter

711583652618e7ec7df8714114f4f23ca5ccdda1

_Note: this commit assumes that we've merged #169._

It does the following things:

1. Extracts a `BaseSplitter` class
2. Creates a `PagesToTiffsSplitter`
3. Creates a `PagesToPngsSplitter`
4. Renames the default configured splitter class to preserve past behavior.

This will allow us to then configure which splitter we use:

1. Favor TIFFs when you want deeper zooms
2. Favor PNGs when you want to minimize storage space

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/293
- https://github.com/scientist-softserv/iiif_print/pull/169

## Extracting BaseSpliter.compression as class attribute

74d9be415d01556c754ffef99b9bdb5338691c0c

Prior to this commit, we were always using a compression algorithm; even
when that algorithm did not apply to PNG.

With this commit, we conditionally apply a compression algorithm based
on the class attribute configuration.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/293
- https://github.com/scientist-softserv/iiif_print/pull/169
