### PR TITLE
Bug fixes due to refactoring

### DIFF
--- a/lib/iiif_print/split_pdfs/base_splitter.rb
+++ b/lib/iiif_print/split_pdfs/base_splitter.rb
@@ -43,7 +43,7 @@ module IiifPrint
       end
 
       attr_reader :pdfinfo, :tmpdir, :baseid, :compression, :default_dpi
-      private :pdfinfo, :tmpdir, :baseid, :compression, :default_dpi
+      private :pdfinfo, :tmpdir, :baseid, :default_dpi
 
       private
 
@@ -61,7 +61,7 @@ module IiifPrint
         # updated during the gsdevice call.
         cmd = "gs -dNOPAUSE -dBATCH -sDEVICE=#{gsdevice} -dTextAlphaBits=4"
         cmd += " -sCompression=#{compression}" if compression?
-        cmd += " -sOutputFile=#{output_base} -r#{ppi} -f #{pdfpath}"
+        cmd += " -sOutputFile=#{output_base} -r#{ppi} -f #{@pdfpath}"
         filenames = []
 
         Open3.popen3(cmd) do |_stdin, stdout, _stderr, _wait_thr|
@@ -86,7 +86,7 @@ module IiifPrint
       def pagecount
         return @pagecount if defined? @pagecount
 
-        cmd = "pdfinfo #{pdfpath}"
+        cmd = "pdfinfo #{@pdfpath}"
         Open3.popen3(cmd) do |_stdin, stdout, _stderr, _wait_thr|
           match = PAGE_COUNT_REGEXP.match(stdout.read)
           @pagecount = match[1].to_i

--- a/lib/iiif_print/text_extraction/page_ocr.rb
+++ b/lib/iiif_print/text_extraction/page_ocr.rb
@@ -22,8 +22,9 @@ module IiifPrint
 
       def run_ocr
         outfile = File.join(Dir.mktmpdir, 'output_html')
-        cmd = "tesseract #{path} #{outfile} hocr"
+        cmd = "tesseract #{path} #{outfile}"
         cmd += " #{@additional_tessearct_options}" if @additional_tessearct_options.present?
+        cmd += " hocr"
         `#{cmd}`
         outfile + '.hocr'
       end


### PR DESCRIPTION
A few minor bugs were introduced during the refactor to clean up and clarify the PDF splitter in preparation for supporting splitting into PNG files. Originated in https://github.com/scientist-softserv/iiif_print/pull/169

Tesseract command was failing because "hocr" needs to come at the end of the tesseract command. Originated in  https://github.com/scientist-softserv/iiif_print/pull/156