### PR TITLE
Update Redis gem

### DIFF
--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -5,7 +5,7 @@ class TestAppGenerator < Rails::Generators::Base
   source_root File.expand_path('../../../spec/test_app_templates', __dir__)
 
   def install_redis
-    gem 'redis', '4.8.0'
+    gem 'redis', '4.8.1'
     Bundler.with_unbundled_env do
       run "bundle install"
     end


### PR DESCRIPTION
In testing, bundle was throwing an error and this seems to fix the problem.  Looks like the Redis gem updated on Feb 10th, 2023.

ref: https://github.com/redis/redis-rb/commit/e4f5299aa0109d1334564f20ae8522866ef554e9