### PR TITLE
Refactor `#file_set_ids`

### DIFF
--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -23,7 +23,7 @@ module IiifPrint
     end
 
     def child_work_has_files?
-      file_set_ids.present?
+      solr_document.try(:file_set_ids).present? || solr_document.try(:[], 'file_set_ids_ssim').present?
     end
   end
 end


### PR DESCRIPTION
This is just a quality of life refactor.  In Essi, when changing any code that has to do with the `WorkShowPresenter` or `SolrDocument`, it for some reason looses the `#file_set_ids` method.  However, if you bracket notate it, it's fine.