### PR TITLE
Add jpg splitter and fix a bug

### DIFF
--- a/lib/iiif_print/split_pdfs/base_splitter.rb
+++ b/lib/iiif_print/split_pdfs/base_splitter.rb
@@ -18,7 +18,7 @@ module IiifPrint
       def initialize(path, tmpdir: Dir.mktmpdir, default_dpi: 400)
         @baseid = SecureRandom.uuid
         @pdfpath = path
-        @pdfinfo = IiifPrint::SplitPdfs::PdfImageExtractionService.new(@pdfpath)
+        @pdfinfo = IiifPrint::SplitPdfs::PdfImageExtractionService.new(pdfpath)
         @tmpdir = tmpdir
         @default_dpi = default_dpi
       end
@@ -43,8 +43,8 @@ module IiifPrint
         false
       end
 
-      attr_reader :pdfinfo, :tmpdir, :baseid, :compression, :default_dpi, :quality
-      private :pdfinfo, :tmpdir, :baseid, :default_dpi
+      attr_reader :pdfinfo, :tmpdir, :baseid, :default_dpi, :pdfpath
+      private :pdfinfo, :tmpdir, :baseid, :default_dpi, :pdfpath
 
       private
 
@@ -62,9 +62,9 @@ module IiifPrint
         # NOTE: you must call gsdevice before compression, as compression is
         # updated during the gsdevice call.
         cmd = "gs -dNOPAUSE -dBATCH -sDEVICE=#{gsdevice} -dTextAlphaBits=4"
-        cmd += " -sCompression=#{self.class.compression}" if self.class.compression?
-        cmd += " -dJPEGQ=#{self.class.quality}" if self.class.quality?
-        cmd += " -sOutputFile=#{output_base} -r#{ppi} -f #{@pdfpath}"
+        cmd += " -sCompression=#{compression}" if compression?
+        cmd += " -dJPEGQ=#{quality}" if quality?
+        cmd += " -sOutputFile=#{output_base} -r#{ppi} -f #{pdfpath}"
         filenames = []
 
         Open3.popen3(cmd) do |_stdin, stdout, _stderr, _wait_thr|
@@ -90,7 +90,7 @@ module IiifPrint
       def pagecount
         return @pagecount if defined? @pagecount
 
-        cmd = "pdfinfo #{@pdfpath}"
+        cmd = "pdfinfo #{pdfpath}"
         Open3.popen3(cmd) do |_stdin, stdout, _stderr, _wait_thr|
           match = PAGE_COUNT_REGEXP.match(stdout.read)
           @pagecount = match[1].to_i

--- a/lib/iiif_print/split_pdfs/pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/pages_to_jpgs_splitter.rb
@@ -1,0 +1,20 @@
+module IiifPrint
+  module SplitPdfs
+    # @abstract
+    #
+    # The purpose of this class is to split the PDF into constituent jpg files.
+    #
+    # @see #each
+    class PagesToJpgsSplitter < BaseSplitter
+      self.image_extension = 'jpg'
+      DEFAULT_QUALITY = '50'.freeze
+      self.quality = DEFAULT_QUALITY
+
+      private
+
+      def gsdevice
+        'jpeg'
+      end
+    end
+  end
+end

--- a/lib/iiif_print/split_pdfs/pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/pages_to_jpgs_splitter.rb
@@ -7,8 +7,7 @@ module IiifPrint
     # @see #each
     class PagesToJpgsSplitter < BaseSplitter
       self.image_extension = 'jpg'
-      DEFAULT_QUALITY = '50'.freeze
-      self.quality = DEFAULT_QUALITY
+      self.quality = '50'
 
       private
 

--- a/spec/iiif_print/base_derivative_service_spec.rb
+++ b/spec/iiif_print/base_derivative_service_spec.rb
@@ -1,11 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe IiifPrint::BaseDerivativeService do
+  let(:file_set) { double(FileSet) }
+  let(:service) { described_class.new(file_set) }
+
   describe '#valid?' do
-    let(:file_set) { double(FileSet) }
-    let(:service) { described_class.new(file_set) }
     subject { service.valid? }
 
     it { is_expected.to be_truthy }
+  end
+
+  describe "instance" do
+    subject { service }
+
+    it { is_expected.to respond_to :target_extension }
   end
 end

--- a/spec/iiif_print/split_pdfs/base_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/base_splitter_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe IiifPrint::SplitPdfs::BaseSplitter do
+  let(:path) { __FILE__ }
+  let(:splitter) { described_class.new(path) }
+
+  describe "instance" do
+    subject { splitter }
+
+    it { is_expected.to respond_to :compression }
+    it { is_expected.to respond_to :compression? }
+    it { is_expected.to respond_to :image_extension }
+    it { is_expected.to respond_to :quality }
+  end
+
+  describe '#compression' do
+    it 'can be changed within the instance' do
+      expect do
+        splitter.compression = 'squishy'
+      end.not_to change(splitter.class, :compression)
+      expect(splitter.compression).to eq('squishy')
+    end
+  end
+end

--- a/spec/iiif_print/split_pdfs/pages_to_jpgs_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/pages_to_jpgs_splitter_spec.rb
@@ -2,18 +2,21 @@ require 'spec_helper'
 require 'misc_shared'
 
 RSpec.describe IiifPrint::SplitPdfs::PagesToJpgsSplitter do
-  describe '.quality' do
-    subject { described_class.quality }
-    it { is_expected.to eq(described_class::DEFAULT_QUALITY) }
+  let(:path) { __FILE__ }
+  let(:splitter) { described_class.new(path) }
+
+  describe '#quality' do
+    subject { splitter.quality }
+    it { is_expected.to eq(described_class.quality) }
   end
 
-  describe '.quality?' do
-    subject { described_class.quality? }
+  describe '#quality?' do
+    subject { splitter.quality? }
     it { is_expected.to be_truthy }
   end
 
-  describe '.image_extension' do
-    subject { described_class.image_extension }
+  describe '#image_extension' do
+    subject { splitter.image_extension }
     it { is_expected.to eq('jpg') }
   end
 end

--- a/spec/iiif_print/split_pdfs/pages_to_jpgs_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/pages_to_jpgs_splitter_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'misc_shared'
+
+RSpec.describe IiifPrint::SplitPdfs::PagesToJpgsSplitter do
+  describe '.quality' do
+    subject { described_class.quality }
+    it { is_expected.to eq(described_class::DEFAULT_QUALITY) }
+  end
+
+  describe '.quality?' do
+    subject { described_class.quality? }
+    it { is_expected.to be_truthy }
+  end
+
+  describe '.image_extension' do
+    subject { described_class.image_extension }
+    it { is_expected.to eq('jpg') }
+  end
+end


### PR DESCRIPTION
When I did some testing in, the PNG files are sometimes even too big. An example would be a 7.1MB PDF creates a 91MB TIFF or 52MB PNG.  This is a big reduction however we can do better.  Without losing noticeable quality, we can generate a 3.8MB JPG.

<img width="1234" alt="image" src="https://user-images.githubusercontent.com/19597776/224737748-b6ea00e9-b320-4aa6-b0cc-1d667ddca7f5.png">

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/19597776/224737826-607413de-0dfd-4e8f-bf28-962b5a06354f.png">

<img width="1218" alt="image" src="https://user-images.githubusercontent.com/19597776/224737874-15070eb1-899f-4b7c-9a3c-60274d0b6ebb.png">

## Add jpg splitter and fix a bug

191472275ff6cce0c224a0d76bb23b22bf60efad

When I did some testing in, the PNG files are sometimes even too big. An
example would be a 7.1MB PDF creates a 91MB TIFF or 52MB PNG.  This is a
big reduction however we can do better.  Without losing noticeable
quality, we can generate a 3.8MB JPG.

## Adding specs to verify class attribute behavior

9bc8adcbf24d9969e068be186339deeb2eea2b1c

Given that we change the compression during the calculation, we cannot
rely on the `self.class.compression` as the correct answer for the
`compression` property.

Instead, we should rely on the instance method (which is derived from
the class attribute's value) to contain the desired `compression` value.
