### PR TITLE
Narrowing list of default service plugins

### DIFF
--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -44,10 +44,7 @@ module IiifPrint
     pdf_splitter_job: IiifPrint::Jobs::ChildWorksFromPdfJob,
     pdf_splitter_service: IiifPrint::SplitPdfs::PagesToTiffsSplitter,
     derivative_service_plugins: [
-      IiifPrint::JP2DerivativeService,
-      IiifPrint::PDFDerivativeService,
-      IiifPrint::TextExtractionDerivativeService,
-      IiifPrint::TIFFDerivativeService
+      IiifPrint::TextExtractionDerivativeService
     ]
   }.freeze
 

--- a/spec/iiif_print_spec.rb
+++ b/spec/iiif_print_spec.rb
@@ -40,10 +40,7 @@ RSpec.describe IiifPrint do
 
       it "has #derivative_service_plugins" do
         expect(record.iiif_print_config.derivative_service_plugins).to eq(
-          [IiifPrint::JP2DerivativeService,
-           IiifPrint::PDFDerivativeService,
-           IiifPrint::TextExtractionDerivativeService,
-           IiifPrint::TIFFDerivativeService]
+          [IiifPrint::TextExtractionDerivativeService]
         )
       end
     end

--- a/spec/iiif_print_spec.rb
+++ b/spec/iiif_print_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe IiifPrint do
       end
 
       it "has a #pdf_splitter_service" do
-        expect(record.iiif_print_config.pdf_splitter_service).to be(IiifPrint::SplitPdfs::PagesToTiffsSplitter)
+        expect(record.iiif_print_config.pdf_splitter_service).to be(IiifPrint::SplitPdfs::PagesToJpgsSplitter)
       end
 
       it "has #derivative_service_plugins" do


### PR DESCRIPTION
Prior to this commit, we were generating several derivatives from the original file.

In conversations with clients, these extra derivatives are often confusing and represent additional processing and storage.  The use cases made more sense for things such as newspapers; in part to normalize the inputs.

The options are still available, but not as part of the default configuration.

With this commit, we reduce the default derivatives we run to a small set.