### PR TITLE
Fix work show presenter

### DIFF
--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -18,7 +18,7 @@ module IiifPrint
     private
 
     # overriding Hyrax to include file sets for both work and child works (file set ids include both)
-    # process each id, short-circuiting the loop once one true value is found. This spees up the test
+    # process each id, short-circuiting the loop once one true value is found. This speeds up the test
     # by not loading more member_presenters than needed.
     def members_include_viewable_image?
       all_member_ids = (solr_document.try(:file_set_ids) || solr_document.try(:[], 'file_set_ids_ssim'))

--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -4,26 +4,35 @@ module IiifPrint
   module WorkShowPresenterDecorator
     delegate :file_set_ids, to: :solr_document
 
-    # OVERRIDE Hyrax 2.9.6 to remove check for representative_presenter.image? and allow
-    # a fallback to check for images on the child works
+    # OVERRIDE Hyrax 2.9.6 to remove check for representative_presenter.image?
     # @return [Boolean] render a IIIF viewer
     def iiif_viewer?
-      parent_work_has_files? || child_work_has_files?
+      Hyrax.config.iiif_image_server? &&
+      representative_id.present? &&
+      representative_presenter.present? &&
+      members_include_viewable_image?
     end
 
     alias universal_viewer? iiif_viewer?
 
     private
 
-    def parent_work_has_files?
-      Hyrax.config.iiif_image_server? &&
-        representative_id.present? &&
-        representative_presenter.present? &&
-        members_include_viewable_image?
+    # overriding Hyrax to include file sets for both work and child works (file set ids include both)
+    # process each id, short-circuiting the loop once one true value is found. This spees up the test
+    # by not loading more member_presenters than needed.
+    def members_include_viewable_image?
+      all_member_ids = (solr_document.try(:file_set_ids) || solr_document.try(:[], 'file_set_ids_ssim'))
+      all_member_ids.each do |id|
+        return true if file_type_and_permissions_valid?(member_presenters_for([id]).first)
+      end
+      false
     end
 
-    def child_work_has_files?
-      solr_document.try(:file_set_ids).present? || solr_document.try(:[], 'file_set_ids_ssim').present?
+    # This method allows for overriding to add additional file types to mix in with IiifAv
+    # TODO: add configuration setting for file types to loop through so an override is unneeded.
+    def file_type_and_permissions_valid?(presenter)
+      current_ability.can?(:read, presenter.id) && 
+      (presenter.try(:image?) || presenter.try(:solr_document).try(:image?))
     end
   end
 end

--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -8,9 +8,9 @@ module IiifPrint
     # @return [Boolean] render a IIIF viewer
     def iiif_viewer?
       Hyrax.config.iiif_image_server? &&
-      representative_id.present? &&
-      representative_presenter.present? &&
-      members_include_viewable_image?
+        representative_id.present? &&
+        representative_presenter.present? &&
+        members_include_viewable_image?
     end
 
     alias universal_viewer? iiif_viewer?
@@ -31,8 +31,8 @@ module IiifPrint
     # This method allows for overriding to add additional file types to mix in with IiifAv
     # TODO: add configuration setting for file types to loop through so an override is unneeded.
     def file_type_and_permissions_valid?(presenter)
-      current_ability.can?(:read, presenter.id) && 
-      (presenter.try(:image?) || presenter.try(:solr_document).try(:image?))
+      current_ability.can?(:read, presenter.id) &&
+        (presenter.try(:image?) || presenter.try(:solr_document).try(:image?))
     end
   end
 end


### PR DESCRIPTION
Ref: https://github.com/scientist-softserv/britishlibrary/issues/303

The prior implementation processed parent and child works separately to determine when to show the iiif_viewer.
However the child works option was incorrect, as it only looked for file_set_ids but didn't check file type or
permission.

This refactor fixes that issue in the most efficient way possible, and also splits out a method which can be overridden to allow for additional file type checks when used in combination with IiifAv gem (and can ultimately be refactored into a config variable).