### PR TITLE
Metadata pain

### DIFF
--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -6,7 +6,7 @@ module IiifPrint
     def manifest_metadata
       current_ability = try(:ability) || try(:current_ability)
       base_url = try(:base_url) || try(:request)&.base_url
-      IiifPrint.manifest_metadata_for(work: model, current_ability: current_ability, base_url: base_url)
+      @metadata ||= IiifPrint.manifest_metadata_for(work: model, current_ability: current_ability, base_url: base_url)
     end
 
     def search_service

--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -3,6 +3,12 @@ module IiifPrint
   module IiifManifestPresenterBehavior
     extend ActiveSupport::Concern
 
+    def manifest_metadata
+      current_ability = try(:ability) || try(:current_ability)
+      base_url = try(:base_url) || try(:request)&.base_url
+      IiifPrint.manifest_metadata_for(work: model, current_ability: current_ability, base_url: base_url)
+    end
+
     def search_service
       Rails.application.routes.url_helpers.solr_document_iiif_search_url(id, host: hostname)
     end

--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -4,9 +4,7 @@ module IiifPrint
     extend ActiveSupport::Concern
 
     def manifest_metadata
-      current_ability = try(:ability) || try(:current_ability)
-      base_url = try(:base_url) || try(:request)&.base_url
-      @metadata ||= IiifPrint.manifest_metadata_for(work: model, current_ability: current_ability, base_url: base_url)
+      @manifest_metadata ||= IiifPrint.manifest_metadata_from(work: model, presenter: self)
     end
 
     def search_service

--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -6,9 +6,13 @@ module IiifPrint
                    &block)
       super(*args, iiif_manifest_factory: iiif_manifest_factory, &block)
       @version = version.to_i
+      @child_works = nil
     end
 
+    attr_reader :child_works
+
     def manifest_for(presenter:)
+      @child_works = get_solr_hits(member_ids_for(presenter))
       build_manifest(presenter: presenter)
     end
 
@@ -37,7 +41,9 @@ module IiifPrint
       manifest = manifest_factory.new(presenter).to_h
       hash = JSON.parse(manifest.to_json)
       hash = send("sanitize_v#{@version}", hash: hash, presenter: presenter)
-      send("sorted_canvases_v#{@version}", hash: hash, sort_field: IiifPrint.config.sort_iiif_manifest_canvases_by)
+      return send("sort_canvases_v#{@version}", hash: hash, sort_field: IiifPrint.config.sort_iiif_manifest_canvases_by) if @child_works.present?
+
+      hash
     end
 
     def sanitize_v2(hash:, presenter:)
@@ -62,11 +68,13 @@ module IiifPrint
     end
 
     def apply_metadata_to_canvas(canvas:, presenter:)
-      solr_hits = get_solr_hits(presenter)
+      return if @child_works.empty?
+
+      parent_and_child_solr_hits = parent_and_child_solr_hits(presenter)
       # uses the 'id' property for v3 manifest and `@id' for v2, which is a URL that contains the FileSet id
       file_set_id = (canvas['id'] || canvas['@id']).split('/').last
       # finds the image that the FileSet is attached to and creates metadata on that canvas
-      image = solr_hits.find { |doc| doc[:member_ids_ssim]&.include?(file_set_id) }
+      image = parent_and_child_solr_hits.find { |doc| doc[:member_ids_ssim]&.include?(file_set_id) }
 
       current_ability = presenter.try(:ability) || presenter.try(:current_ability)
       base_url = presenter.try(:base_url) || presenter.try(:request)&.base_url
@@ -78,7 +86,7 @@ module IiifPrint
 
     LARGEST_SORT_ORDER_CHAR = '~'.freeze
 
-    def sorted_canvases_v2(hash:, sort_field:)
+    def sort_canvases_v2(hash:, sort_field:)
       sort_field = Hyrax::Renderers::AttributeRenderer.new(sort_field, nil).label
       hash['sequences']&.first&.[]('canvases')&.sort_by! do |canvas|
         selection = canvas['metadata'].select { |h| h['label'] == sort_field }
@@ -90,7 +98,7 @@ module IiifPrint
       hash
     end
 
-    def sorted_canvases_v3(hash:, sort_field:)
+    def sort_canvases_v3(hash:, sort_field:)
       sort_field = Hyrax::Renderers::AttributeRenderer.new(sort_field, nil).label
       hash['items']&.sort_by! do |item|
         selection = item['metadata'].select { |h| h['label'][I18n.locale.to_s] == [sort_field] }
@@ -102,8 +110,20 @@ module IiifPrint
       hash
     end
 
-    def get_solr_hits(presenter)
-      ids = [presenter.id] + Array.wrap(presenter.try(:ordered_ids) || presenter.try(:member_ids))
+    def member_ids_for(presenter)
+      presenter.try(:ordered_ids) || presenter.try(:member_ids)
+    end
+
+    def parent_and_child_solr_hits(presenter)
+      ids = [presenter.id] + member_ids_for(presenter)
+      get_solr_hits(ids)
+    end
+
+    ##
+    # return an array of work SolrHits
+    # @param ids [Array]
+    # @return [Array<ActiveFedora::SolrHit>]
+    def get_solr_hits(ids)
       ids.flat_map { |id| ActiveFedora::SolrService.query("id:#{id}", fq: "-has_model_ssim:FileSet", rows: ids.size) }
     end
   end

--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -76,11 +76,7 @@ module IiifPrint
       # finds the image that the FileSet is attached to and creates metadata on that canvas
       image = parent_and_child_solr_hits.find { |doc| doc[:member_ids_ssim]&.include?(file_set_id) }
 
-      current_ability = presenter.try(:ability) || presenter.try(:current_ability)
-      base_url = presenter.try(:base_url) || presenter.try(:request)&.base_url
-      canvas_metadata = IiifPrint.manifest_metadata_for(work: image,
-                                                        current_ability: current_ability,
-                                                        base_url: base_url)
+      canvas_metadata = IiifPrint.manifest_metadata_from(work: image, presenter: presenter)
       canvas['metadata'] = canvas_metadata
     end
 

--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -111,7 +111,8 @@ module IiifPrint
     end
 
     def member_ids_for(presenter)
-      presenter.try(:ordered_ids) || presenter.try(:member_ids)
+      member_ids = presenter.try(:ordered_ids) || presenter.try(:member_ids)
+      member_ids.nil? ? [] : member_ids
     end
 
     def parent_and_child_solr_hits(presenter)
@@ -124,7 +125,8 @@ module IiifPrint
     # @param ids [Array]
     # @return [Array<ActiveFedora::SolrHit>]
     def get_solr_hits(ids)
-      ids.flat_map { |id| ActiveFedora::SolrService.query("id:#{id}", fq: "-has_model_ssim:FileSet", rows: ids.size) }
+      query = "id:(#{ids.join(' OR ')})"
+      ActiveFedora::SolrService.query(query, fq: "-has_model_ssim:FileSet", rows: ids.size)
     end
   end
 end

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -161,11 +161,8 @@ module IiifPrint
         options: options
       )
     end
-    # Adding collection metadata for display in the UV metadata pane
-    if fields.where(name: 'collection').empty?
-      collection_field = Field.new(name: :collection, label: 'Collection', options: nil)
-      flex_fields << collection_field
-    end
+    return flex_fields << @collection_field if @collection_field.present?
+
     flex_fields
   end
 
@@ -188,5 +185,8 @@ module IiifPrint
                               .where(allinson_flex_profile_texts: { name: 'display_label' })
                               .distinct
                               .select(:name, :value, :indexing)
+    # Adding collection metadata for display in the UV metadata pane
+    @collection_field ||= Field.new(name: :collection, label: 'Collection', options: nil) unless @allinson_flex_fields.exists?(name: 'collection')
+    @allinson_flex_fields
   end
 end

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -135,9 +135,7 @@ module IiifPrint
   def self.manifest_metadata_from(work:, presenter:)
     current_ability = presenter.try(:ability) || presenter.try(:current_ability)
     base_url = presenter.try(:base_url) || presenter.try(:request)&.base_url
-    canvas_metadata = IiifPrint.manifest_metadata_for(work: work,
-                                                      current_ability: current_ability,
-                                                      base_url: base_url)
+    IiifPrint.manifest_metadata_for(work: work, current_ability: current_ability, base_url: base_url)
   end
   # Hash is an arbitrary attribute key/value pairs
   # Struct is a defined set of attribute "keys".  When we favor defined values,
@@ -189,10 +187,10 @@ module IiifPrint
     #   )
     # In this ActiveRecord query, allinson_flex_profile_properties.indexing was added
     allinson_flex_relation = AllinsonFlex::ProfileProperty
-                            .joins(:texts)
-                            .where(allinson_flex_profile_texts: { name: 'display_label' })
-                            .distinct
-                            .select(:name, :value, :indexing)
+                             .joins(:texts)
+                             .where(allinson_flex_profile_texts: { name: 'display_label' })
+                             .distinct
+                             .select(:name, :value, :indexing)
     flex_fields = allinson_flex_relation.to_a
     unless allinson_flex_relation.exists?(name: 'collection')
       collection_field = CollectionFieldShim.new(name: :collection, value: 'Collection', indexing: [])

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -150,7 +150,7 @@ module IiifPrint
   end
 
   def self.allinson_flex_fields_for(_work, fields: allinson_flex_fields)
-    fields.map do |field|
+    flex_fields = fields.map do |field|
       # currently only supports the faceted option
       # Why the `render_as:`? This was originally derived from Hyku default attributes
       # @see https://github.com/samvera/hyku/blob/c702844de4c003eaa88eb5a7514c7a1eae1b289e/app/views/hyrax/base/_attribute_rows.html.erb#L3
@@ -161,6 +161,12 @@ module IiifPrint
         options: options
       )
     end
+    # Adding collection metadata for display in the UV metadata pane
+    if fields.where(name: 'collection').empty?
+      collection_field = Field.new(name: :collection, label: 'Collection', options: nil)
+      flex_fields << collection_field
+    end
+    flex_fields
   end
 
   def self.allinson_flex_fields


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/19597776/225964953-25a613a5-799f-4c85-95e4-267f2c6f5a05.png)


[Add collection metadata to Allinson Flex](https://github.com/scientist-softserv/iiif_print/commit/2f96b5a810003045251d07e7c0aefd5267e64c29) 

Assuming Allinson Flex does not implement a property called 'collection'
to return the work's collection, this commit will inject the property so
it is available to be viewed in the metadata pane.  This will be in
parity with non-Allinson Flex applications.

---

[Add metadata to the parent](https://github.com/scientist-softserv/iiif_print/commit/b07dff66569bd243e8bb2f163edbee69210ed866) 

Previously, the metadata would always sit on the child canvas.  This
would fail to render any metadata for the parent work.  This commit will
fix that.

