### PR TITLE
I 187 search recent works

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ TO ENABLE OCR Search (from the UV and catalog search)
     }
 ```
 
+To remove child works from recent works on homepage 
+### homepage_controller.rb
+* In the HomepageController, change the search_builder_class to remove works from recent_documents if `is_child_bsi: true`
+```rb
+    def search_builder_class
+      IiifPrint::HomepageSearchBuilder
+    end
+```
+
 # Ingesting Content
 
 IiifPrint supports a range of different ingest workflows:

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ To remove child works from recent works on homepage
 ### homepage_controller.rb
 * In the HomepageController, change the search_builder_class to remove works from recent_documents if `is_child_bsi: true`
 ```rb
+    require "iiif_print/homepage_search_builder"
+
     def search_builder_class
       IiifPrint::HomepageSearchBuilder
     end

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -12,7 +12,6 @@ module IiifPrint
 
     # rubocop:disable Metrics/BlockLength
     config.to_prepare do
-      require "iiif_print/homepage_search_builder"
       # We don't have a hard requirement of Bullkrax but in our experience, lingering on earlier
       # versions can introduce bugs of both Bulkrax and some of the assumptions that we've resolved.
       # Very early versions of Bulkrax do not have VERSION defined

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -12,6 +12,7 @@ module IiifPrint
 
     # rubocop:disable Metrics/BlockLength
     config.to_prepare do
+      require "iiif_print/homepage_search_builder"
       # We don't have a hard requirement of Bullkrax but in our experience, lingering on earlier
       # versions can introduce bugs of both Bulkrax and some of the assumptions that we've resolved.
       # Very early versions of Bulkrax do not have VERSION defined

--- a/lib/iiif_print/homepage_search_builder.rb
+++ b/lib/iiif_print/homepage_search_builder.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'hyrax/homepage_search_builder'
+
+# Overrides Hyrax to add show_parents_only to processor chain
+module IiifPrint
+  class HomepageSearchBuilder < Hyrax::HomepageSearchBuilder
+    include Hyrax::FilterByType
+    self.default_processor_chain += [:add_access_controls_to_solr_params, :show_parents_only]
+
+    def only_works?
+      true
+    end
+
+    def show_parents_only(solr_parameters)
+      query = if blacklight_params["include_child_works"] == 'true'
+                ActiveFedora::SolrQueryBuilder.construct_query(is_child_bsi: 'true')
+              else
+                ActiveFedora::SolrQueryBuilder.construct_query(is_child_bsi: nil)
+              end
+      solr_parameters[:fq] += [query]
+    end
+  end
+end

--- a/lib/iiif_print/homepage_search_builder.rb
+++ b/lib/iiif_print/homepage_search_builder.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
-require 'hyrax/homepage_search_builder'
 
 # Overrides Hyrax to add show_parents_only to processor chain
 module IiifPrint
   class HomepageSearchBuilder < Hyrax::HomepageSearchBuilder
-    include Hyrax::FilterByType
-    self.default_processor_chain += [:add_access_controls_to_solr_params, :show_parents_only]
-
-    def only_works?
-      true
-    end
+    self.default_processor_chain += [:show_parents_only]
 
     def show_parents_only(solr_parameters)
       query = if blacklight_params["include_child_works"] == 'true'


### PR DESCRIPTION
ref https://github.com/scientist-softserv/iiif_print/issues/187

Recent works on the home page should not include child works. 

This implements a homepage search builder for iiif_print which adds `:show_parents_only` to the processor chain.

<details>
<summary>
Screenshot:
</summary>

![Screenshot 2023-03-17 at 5 47 58 PM](https://user-images.githubusercontent.com/17851674/226059352-6508068e-677e-4ae3-a803-38f0cc9dccc0.png)
</details>