### PR TITLE
Remove empty strings from metadata pane

### DIFF
--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -122,7 +122,7 @@ module IiifPrint
   # @see Hyrax::IiifManifestPresenter#manifest_metadata
   def self.manifest_metadata_for(work:,
                                  version: config.default_iiif_manifest_version,
-                                 fields: defined?(AllinsonFlex) ? allinson_flex_fields_for(work) : default_fields_for(work),
+                                 fields: defined?(AllinsonFlex) ? fields_for_allinson_flex : default_fields,
                                  current_ability:,
                                  base_url:)
     Metadata.build_metadata_for(work: work,
@@ -144,7 +144,7 @@ module IiifPrint
 
   # @api private
   # @todo Figure out a way to use a custom label, right now it takes it get rendered from the title.
-  def self.default_fields_for(_work, fields: config.metadata_fields)
+  def self.default_fields(fields: config.metadata_fields)
     fields.map do |field|
       Field.new(
         name: field.first,
@@ -154,7 +154,7 @@ module IiifPrint
     end
   end
 
-  def self.allinson_flex_fields_for(_work, fields: allinson_flex_fields)
+  def self.fields_for_allinson_flex(fields: allinson_flex_fields)
     fields.map do |field|
       # currently only supports the faceted option
       # Why the `render_as:`? This was originally derived from Hyku default attributes

--- a/lib/iiif_print/metadata.rb
+++ b/lib/iiif_print/metadata.rb
@@ -1,4 +1,5 @@
 module IiifPrint
+  # rubocop:disable Metrics/ClassLength
   class Metadata
     def self.build_metadata_for(work:, version:, fields:, current_ability:, base_url:)
       new(work: work,
@@ -20,10 +21,11 @@ module IiifPrint
 
     def build_metadata
       fields.map do |field|
+        values = values_for(field_name: field)
         if field.name == :collection && member_of_collection? && viewable_collections.present?
           { 'label' => metadata_map(field, :label),
             'value' => metadata_map(field, :collection) }
-        elsif values_for(field_name: field).present?
+        elsif values.present? && !empty_string?(values)
           { 'label' => metadata_map(field, :label),
             'value' => metadata_map(field, :value) }
         end
@@ -46,6 +48,12 @@ module IiifPrint
         when :collection then { 'none' => make_collection_link(viewable_collections) }
         end
       end
+    end
+
+    # Bulkrax imports values as [""] if there isn't a value but still a header,
+    # these fields should not show in the metadata pane
+    def empty_string?(values)
+      values.uniq.size == 1 ? values.first == "" : false
     end
 
     def member_of_collection?
@@ -114,4 +122,5 @@ module IiifPrint
       )
     }ix.freeze
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/spec/iiif_print/metadata_spec.rb
+++ b/spec/iiif_print/metadata_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe IiifPrint::Metadata do
   let(:base_url) { "https://my.dev.test" }
   let(:solr_hit) { SolrHit.new(attributes) }
-  let(:fields) { IiifPrint.default_fields_for(fields: metadata_fields) }
+  let(:fields) { IiifPrint.default_fields(fields: metadata_fields) }
   let(:metadata_fields) do
     {
       title: {},
@@ -86,6 +86,23 @@ RSpec.describe IiifPrint::Metadata do
           ]
         end
       end
+
+      context "when the value has an empty string" do
+        let(:attributes) { { "title_tesim" => ["This is a title."], "description_tesim" => [""] } }
+
+        it "does not map the field with an empty string" do
+          expect(manifest_metadata.flat_map(&:values)).not_to include([""])
+          expect(manifest_metadata).to eq [{ "label" => "Title", "value" => ["This is a title."] }]
+        end
+      end
+
+      context "when the value is an empty string" do
+        let(:attributes) { { "description_tesim" => [""] } }
+
+        it "returns and empty array" do
+          expect(manifest_metadata).to eq []
+        end
+      end
     end
 
     context "for version 3 of the IIIF spec" do
@@ -148,6 +165,23 @@ RSpec.describe IiifPrint::Metadata do
             { "label" => { "en" => ["Collection"] },
               "value" => { "none" => ["<a href='#{base_url}/collections/321cba'>My Cool Collection</a>"] } }
           ]
+        end
+      end
+
+      context "when the value has an empty string" do
+        let(:attributes) { { "title_tesim" => ["This is a title."], "description_tesim" => [""] } }
+
+        it "does not map the field with an empty string" do
+          expect(manifest_metadata.flat_map(&:values)).not_to include({"none"=>[""]})
+          expect(manifest_metadata).to eq [{ "label" => { "en" => ["Title"] }, "value" => { "none" => ["This is a title."] } }]
+        end
+      end
+
+      context "when the value is an empty string" do
+        let(:attributes) { { "description_tesim" => [""] } }
+
+        it "returns and empty array" do
+          expect(manifest_metadata).to eq []
         end
       end
     end

--- a/spec/iiif_print/metadata_spec.rb
+++ b/spec/iiif_print/metadata_spec.rb
@@ -172,8 +172,10 @@ RSpec.describe IiifPrint::Metadata do
         let(:attributes) { { "title_tesim" => ["This is a title."], "description_tesim" => [""] } }
 
         it "does not map the field with an empty string" do
-          expect(manifest_metadata.flat_map(&:values)).not_to include({"none"=>[""]})
-          expect(manifest_metadata).to eq [{ "label" => { "en" => ["Title"] }, "value" => { "none" => ["This is a title."] } }]
+          expect(manifest_metadata.flat_map(&:values)).not_to include({ "none" => [""] })
+          expect(manifest_metadata).to eq [
+            { "label" => { "en" => ["Title"] }, "value" => { "none" => ["This is a title."] } }
+          ]
         end
       end
 


### PR DESCRIPTION
This commit will remove empty strings from showing in the metadata pane. This occurs in a Bulkrax import when the header exists but there isn't a value.  Bulkrax would then map that property to `""`.  This would then show up in the metadata pane as just a label since the value is blank. Also in the commit, cleaned up some specs and removed `_work` from the `.default_fields` and `.fields_for_allinson_flex` because it was messing up the testing.

Before:
<img width="273" alt="image" src="https://user-images.githubusercontent.com/19597776/226626908-80fd8304-2497-4e87-9c50-408e27f63523.png">


After:
<img width="278" alt="image" src="https://user-images.githubusercontent.com/19597776/226626235-7525e169-f598-408b-b64f-bb2e8105cee6.png">
