### PR TITLE
Sequence child works by pdf & page

### DIFF
--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -80,12 +80,10 @@ module IiifPrint
           # save child work info to create the member relationships
           PendingRelationship.create!(child_title: file_title,
                                       parent_id: @parent_work.id,
-                                      child_order: sort_order(
-                                        pdf_sequence,
-                                        idx,
-                                        pdf_pad_zero: number_of_digits(nbr: number_of_pdfs),
-                                        page_pad_zero: number_of_digits(nbr: pdf_number_of_pages))
-                                      )
+                                      child_order: sort_order(pdf_sequence,
+                                                              idx,
+                                                              pdf_pad_zero: number_of_digits(nbr: number_of_pdfs),
+                                                              page_pad_zero: number_of_digits(nbr: pdf_number_of_pages)))
         end
       end
       # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
Titles were padded to cause child works to show sequentially in the universal viewer. However, the ordered members being added were not padded to cause the same sequencing. This commit also pads the pdf & page numbers being used to order the child works so they will be sequenced correctly.

Ref https://github.com/scientist-softserv/britishlibrary/issues/339 as pages > 10 were previously out of sequence on the work show page.

<details>
<summary>Before & After Screenshots</summary

**Before:**
![Screenshot 2023-03-21 at 5 41 25 PM](https://user-images.githubusercontent.com/17851674/226747908-4deade00-8e3e-412d-8aec-d1fdd574e308.png)

**After:**
![Screenshot 2023-03-21 at 5 40 55 PM](https://user-images.githubusercontent.com/17851674/226747917-e209b263-3480-4a80-afe9-323c284e36f7.png)

</details>