### PR TITLE
[i335] - port over serverless code from nnp

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ IiifPrint supports:
 * configuring how the manifest canvases are sorted in the viewer
 * adding metadata fields to the manifest with faceted search links and external links
 * excluding specified work types to be found in the catalog search
-* external IIIF image urls that work with services such as AWS
+* external IIIF image urls that work with services such as serverless-iiif or cantaloup
 
 A complete list of features can be found [here](https://github.com/scientist-softserv/iiif_print/wiki/Features-List).
 
@@ -92,6 +92,10 @@ IiifPrint easily integrates with your Hyrax 2.x applications.
 
 ## Configuration to enable IiifPrint features
 **NOTE: WorkTypes and models are used synonymously here.**
+
+### IIIF URL configuration
+
+If you set EXTERNAL_IIIF_URL in your environment, then IiifPrint will use that URL as the root for your IIIF URLs. It will also switch from using the file set ID to using the SHA1 of the file as the identifier. This enables using serverless_iiif or Cantaloupe (refered to as the service) by pointing the service to the same S3 bucket that FCREPO writes the uploaded files to. By setting it up that way you do not need the service to connect to FCREPO or Hyrax at all, both natively support connecting to an S3 bucket to get their data.
 
 ### Model level configurations
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ IiifPrint supports:
 * configuring how the manifest canvases are sorted in the viewer
 * adding metadata fields to the manifest with faceted search links and external links
 * excluding specified work types to be found in the catalog search
+* external IIIF image urls that work with services such as AWS
 
 A complete list of features can be found [here](https://github.com/scientist-softserv/iiif_print/wiki/Features-List).
 
@@ -153,7 +154,7 @@ TO ENABLE OCR Search (from the UV and catalog search)
     }
 ```
 
-To remove child works from recent works on homepage 
+To remove child works from recent works on homepage
 ### homepage_controller.rb
 * In the HomepageController, change the search_builder_class to remove works from recent_documents if `is_child_bsi: true`
 ```rb

--- a/app/indexers/concerns/iiif_print/file_set_indexer.rb
+++ b/app/indexers/concerns/iiif_print/file_set_indexer.rb
@@ -24,15 +24,14 @@ module IiifPrint
         solr_doc['all_text_timv'] = text
         solr_doc['all_text_tsimv'] = text
         solr_doc['digest_ssim'] = digest_from_content
-
       end
     end
 
         private
 
-      def digest_from_content
-        return unless object.original_file
-        object.original_file.digest.first.to_s
-      end
+    def digest_from_content
+      return unless object.original_file
+      object.original_file.digest.first.to_s
+    end
   end
 end

--- a/app/indexers/concerns/iiif_print/file_set_indexer.rb
+++ b/app/indexers/concerns/iiif_print/file_set_indexer.rb
@@ -27,7 +27,7 @@ module IiifPrint
       end
     end
 
-        private
+    private
 
     def digest_from_content
       return unless object.original_file

--- a/app/indexers/concerns/iiif_print/file_set_indexer.rb
+++ b/app/indexers/concerns/iiif_print/file_set_indexer.rb
@@ -23,7 +23,16 @@ module IiifPrint
         text = text.tr("\n", ' ').squeeze(' ')
         solr_doc['all_text_timv'] = text
         solr_doc['all_text_tsimv'] = text
+        solr_doc['digest_ssim'] = digest_from_content
+
       end
     end
+
+        private
+
+      def digest_from_content
+        return unless object.original_file
+        object.original_file.digest.first.to_s
+      end
   end
 end

--- a/app/models/concerns/iiif_print/solr/document.rb
+++ b/app/models/concerns/iiif_print/solr/document.rb
@@ -19,6 +19,7 @@ module IiifPrint::Solr::Document
   def self.decorate(base)
     base.prepend(self)
     base.send(:attribute, :is_child, Hyrax::SolrDocument::Metadata::Solr::String, 'is_child_bsi')
+    base.send(:attribute, :digest, Hyrax::SolrDocument::Metadata::Solr::String, 'digest_ssim')
 
     # @note These properties came from the newspaper_works gem.  They are configurable.
     base.class_attribute :iiif_print_solr_field_names, default: %w[alternative_title genre
@@ -29,6 +30,10 @@ module IiifPrint::Solr::Document
                                                                    edition_number edition_name frequency preceded_by
                                                                    succeeded_by]
     base
+  end
+
+  def digest_sha1
+    digest[/urn:sha1:([\w]+)/, 1]
   end
 
   def method_missing(method_name, *args, &block)

--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -28,7 +28,6 @@ module IiifPrint
 
     module DisplayImagePresenterBehavior
       def display_image
-        # return nil unless model.image?
         return nil unless latest_file_id
 
         IIIFManifest::DisplayImage
@@ -41,11 +40,8 @@ module IiifPrint
 
       def display_image_url(base_url)
         if ENV['SERVERLESS_IIIF_URL'].present?
-          Hyrax.config.iiif_image_url_builder.call(
-            latest_file_id,
-            ENV['SERVERLESS_IIIF_URL'],
-            Hyrax.config.iiif_image_size_default
-          ).gsub(%r{images/}, '')
+          # At the moment we are only concerned about Hyrax's default image url builder
+          iiif_image_url_builder(url_builder: Hyrax.config.iiif_image_url_builder)
         else
           super
         end
@@ -72,7 +68,7 @@ module IiifPrint
         false
       end
 
-        private
+      private
 
       def latest_file_id
         if ENV['SERVERLESS_IIIF_URL'].present?
@@ -84,6 +80,18 @@ module IiifPrint
 
       def serverless_latest_file_id
         @latest_file_id ||= digest_sha1
+      end
+
+      def iiif_image_url_builder(url_builder:)
+        args = [
+          latest_file_id,
+          ENV['SERVERLESS_IIIF_URL'],
+          Hyrax.config.iiif_image_size_default
+        ]
+        # In Hyrax 3, Hyrax.config.iiif_image_url_builder takes an additional argument
+        args << image_format(alpha_channels) if url_builder.arity == 4
+
+        url_builder.call(*args).gsub(%r{images/}, '')
       end
     end
   end

--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -26,65 +26,65 @@ module IiifPrint
       end.flatten
     end
 
-      module DisplayImagePresenterBehavior
-        def display_image
-          return nil unless model.image?
-          return nil unless latest_file_id
+    module DisplayImagePresenterBehavior
+      def display_image
+        # return nil unless model.image?
+        return nil unless latest_file_id
 
-          IIIFManifest::DisplayImage
-            .new(display_image_url(hostname),
-                format: image_format(alpha_channels),
-                width: width,
-                height: height,
-                iiif_endpoint: iiif_endpoint(latest_file_id, base_url: hostname))
-        end
+        IIIFManifest::DisplayImage
+          .new(display_image_url(hostname),
+              format: image_format(alpha_channels),
+              width: width,
+              height: height,
+              iiif_endpoint: iiif_endpoint(latest_file_id, base_url: hostname))
+      end
 
-        def display_image_url(base_url)
-          if ENV['SERVERLESS_IIIF_URL'].present?
-            Hyrax.config.iiif_image_url_builder.call(
-              latest_file_id,
-              ENV['SERVERLESS_IIIF_URL'],
-              Hyrax.config.iiif_image_size_default
-            ).gsub(%r{images/}, '')
-          else
-            super
-          end
+      def display_image_url(base_url)
+        if ENV['SERVERLESS_IIIF_URL'].present?
+          Hyrax.config.iiif_image_url_builder.call(
+            latest_file_id,
+            ENV['SERVERLESS_IIIF_URL'],
+            Hyrax.config.iiif_image_size_default
+          ).gsub(%r{images/}, '')
+        else
+          super
         end
-    
-        def iiif_endpoint(file_id, base_url: request.base_url)
-          if ENV['SERVERLESS_IIIF_URL'].present?
-            IIIFManifest::IIIFEndpoint.new(
-              File.join(ENV['SERVERLESS_IIIF_URL'], file_id),
-              profile: Hyrax.config.iiif_image_compliance_level_uri
-            )
-          else
-            super
-          end
+      end
+
+      def iiif_endpoint(file_id, base_url: request.base_url)
+        if ENV['SERVERLESS_IIIF_URL'].present?
+          IIIFManifest::IIIFEndpoint.new(
+            File.join(ENV['SERVERLESS_IIIF_URL'], file_id),
+            profile: Hyrax.config.iiif_image_compliance_level_uri
+          )
+        else
+          super
         end
-    
-        def hostname
-          @hostname || 'localhost'
+      end
+
+      def hostname
+        @hostname || 'localhost'
+      end
+
+      ##
+      # @return [Boolean] false
+      def work?
+        false
+      end
+
+        private
+
+      def latest_file_id
+        if ENV['SERVERLESS_IIIF_URL'].present?
+          serverless_latest_file_id
+        else
+          super
         end
-    
-        ##
-        # @return [Boolean] false
-        def work?
-          false
-        end
-    
-          private
-    
-            def latest_file_id
-              if ENV['SERVERLESS_IIIF_URL'].present?
-                serverless_latest_file_id
-              else
-                super
-              end
-            end
-    
-            def serverless_latest_file_id
-              @latest_file_id ||= digest_sha1
-            end
+      end
+
+      def serverless_latest_file_id
+        @latest_file_id ||= digest_sha1
+      end
     end
   end
 end

--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -3,6 +3,10 @@ module IiifPrint
   module IiifManifestPresenterBehavior
     extend ActiveSupport::Concern
 
+    # Extending the presenter to the base url which includes the protocol.
+    # We need the base url to render the facet links and normalize the interface.
+    attr_accessor :base_url
+
     def manifest_metadata
       @manifest_metadata ||= IiifPrint.manifest_metadata_from(work: model, presenter: self)
     end
@@ -11,7 +15,7 @@ module IiifPrint
       Rails.application.routes.url_helpers.solr_document_iiif_search_url(id, host: hostname)
     end
 
-    # OVERRIDE Hyrax 3x, avoid nil returning to IIIF Manifest gem
+    # OVERRIDE: Hyrax 3x, avoid nil returning to IIIF Manifest gem
     # @see https://github.com/samvera/iiif_manifest/blob/c408f90eba11bef908796c7236ba6bcf8d687acc/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb#L28
     ##
     # @return [Array<Hash{String => String}>]
@@ -26,20 +30,47 @@ module IiifPrint
       end.flatten
     end
 
+    # OVERRIDE: Hyrax v3.x
     module DisplayImagePresenterBehavior
+      # Extending the presenter to the base url which includes the protocol.
+      # We need the base url to render the facet links and normalize the interface.
+      attr_accessor :base_url
+
+      # Extending this class because there is an #ability= but not #ability and this definition
+      # mirrors the Hyrax::IiifManifestPresenter#ability.
+      def ability
+        @ability ||= NullAbility.new
+      end
+
       def display_image
         return nil unless latest_file_id
+        return nil unless model.image?
+        return nil unless IiifPrint.config.default_iiif_manifest_version == 2
 
         IIIFManifest::DisplayImage
           .new(display_image_url(hostname),
-              format: image_format(alpha_channels),
-              width: width,
-              height: height,
-              iiif_endpoint: iiif_endpoint(latest_file_id, base_url: hostname))
+            format: image_format(alpha_channels),
+            width: width,
+            height: height,
+            iiif_endpoint: iiif_endpoint(latest_file_id, base_url: hostname))
+      end
+
+      # OVERRIDE: IIIF Hyrax AV v0.2 #display_content for prez 3 manifests
+      def display_content
+        return nil unless latest_file_id
+        return super unless model.image?
+
+        IIIFManifest::V3::DisplayContent
+          .new(display_image_url(hostname),
+            format: image_format(alpha_channels),
+            width: width,
+            height: height,
+            type: 'Image',
+            iiif_endpoint: iiif_endpoint(latest_file_id, base_url: hostname))
       end
 
       def display_image_url(base_url)
-        if ENV['SERVERLESS_IIIF_URL'].present?
+        if ENV['EXTERNAL_IIIF_URL'].present?
           # At the moment we are only concerned about Hyrax's default image url builder
           iiif_image_url_builder(url_builder: Hyrax.config.iiif_image_url_builder)
         else
@@ -48,9 +79,9 @@ module IiifPrint
       end
 
       def iiif_endpoint(file_id, base_url: request.base_url)
-        if ENV['SERVERLESS_IIIF_URL'].present?
+        if ENV['EXTERNAL_IIIF_URL'].present?
           IIIFManifest::IIIFEndpoint.new(
-            File.join(ENV['SERVERLESS_IIIF_URL'], file_id),
+            File.join(ENV['EXTERNAL_IIIF_URL'], file_id),
             profile: Hyrax.config.iiif_image_compliance_level_uri
           )
         else
@@ -71,21 +102,21 @@ module IiifPrint
       private
 
       def latest_file_id
-        if ENV['SERVERLESS_IIIF_URL'].present?
-          serverless_latest_file_id
+        if ENV['EXTERNAL_IIIF_URL'].present?
+          external_latest_file_id
         else
           super
         end
       end
 
-      def serverless_latest_file_id
+      def external_latest_file_id
         @latest_file_id ||= digest_sha1
       end
 
       def iiif_image_url_builder(url_builder:)
         args = [
           latest_file_id,
-          ENV['SERVERLESS_IIIF_URL'],
+          ENV['EXTERNAL_IIIF_URL'],
           Hyrax.config.iiif_image_size_default
         ]
         # In Hyrax 3, Hyrax.config.iiif_image_url_builder takes an additional argument

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -49,19 +49,6 @@ module IiifPrint
       ::BlacklightIiifSearch::IiifSearchAnnotation.prepend(IiifPrint::BlacklightIiifSearch::AnnotationDecorator)
       Hyrax::Actors::FileSetActor.prepend(IiifPrint::Actors::FileSetActorDecorator)
 
-      # Extending the presenter to the base url which includes the protocol.
-      # We need the base url to render the facet links and normalize the interface.
-      Hyrax::IiifManifestPresenter.send(:attr_accessor, :base_url)
-      Hyrax::IiifManifestPresenter::DisplayImagePresenter.send(:attr_accessor, :base_url)
-      # Extending this class because there is an #ability= but not #ability and this definition
-      # mirrors the Hyrax::IiifManifestPresenter#ability.
-      module Hyrax::IiifManifestPresenter::DisplayImagePresenterDecorator
-        def ability
-          @ability ||= NullAbility.new
-        end
-      end
-      Hyrax::IiifManifestPresenter::DisplayImagePresenter.prepend(Hyrax::IiifManifestPresenter::DisplayImagePresenterDecorator)
-
       Hyrax.config do |config|
         config.callback.set(:after_create_fileset) do |file_set, user|
           IiifPrint.config.handle_after_create_fileset(file_set, user)

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -68,9 +68,11 @@ module IiifPrint
         end
       end
     end
-
+    
     config.after_initialize do
       IiifPrint::Solr::Document.decorate(SolrDocument)
+      Hyrax::IiifManifestPresenter::DisplayImagePresenter
+      .prepend(IiifPrint::IiifManifestPresenterBehavior::DisplayImagePresenterBehavior)
     end
     # rubocop:enable Metrics/BlockLength
   end

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -68,11 +68,11 @@ module IiifPrint
         end
       end
     end
-    
+
     config.after_initialize do
       IiifPrint::Solr::Document.decorate(SolrDocument)
       Hyrax::IiifManifestPresenter::DisplayImagePresenter
-      .prepend(IiifPrint::IiifManifestPresenterBehavior::DisplayImagePresenterBehavior)
+        .prepend(IiifPrint::IiifManifestPresenterBehavior::DisplayImagePresenterBehavior)
     end
     # rubocop:enable Metrics/BlockLength
   end

--- a/spec/presenters/iiif_print/iiif_manifest_presenter_behavior_spec.rb
+++ b/spec/presenters/iiif_print/iiif_manifest_presenter_behavior_spec.rb
@@ -16,4 +16,33 @@ RSpec.describe IiifPrint::IiifManifestPresenterBehavior do
       expect(presenter.search_service).to include("#{solr_document.id}/iiif_search")
     end
   end
+
+  # this method is inside of the DisplayImagePresenterBehavior module
+  describe '#display_image' do
+    let(:presenter) { Hyrax::IiifManifestPresenter::DisplayImagePresenter.new(solr_document) }
+    let(:id) { 'abc123' }
+
+    context 'when serverless_iiif is enabled' do
+      let(:url) { 'serverless_iiif_url' }
+
+      it 'renders a serverless url' do
+        allow(ENV).to receive(:[])
+        allow(ENV).to receive(:[]).with('SERVERLESS_IIIF_URL').and_return(url)
+        allow(presenter).to receive(:latest_file_id).and_return(id)
+        expect(presenter.display_image.iiif_endpoint.url).to eq "#{url}/#{id}"
+        expect(presenter.display_image.iiif_endpoint.profile).to eq "http://iiif.io/api/image/2/level2.json"
+      end
+    end
+
+    context 'when serverless_iiif is not enabled' do
+      let(:iiif_info_url_builder) { ->(file_id, base_url) { "#{base_url}/#{file_id}" } }
+
+      it 'does not render a serverless url' do
+        allow(presenter).to receive(:latest_file_id).and_return(id)
+        allow(Hyrax.config).to receive(:iiif_image_server?).and_return(true)
+        allow(Hyrax.config).to receive(:iiif_info_url_builder).and_return(iiif_info_url_builder)
+        expect(presenter.display_image.iiif_endpoint.url).to eq "localhost/#{id}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Summary

ref: https://github.com/scientist-softserv/britishlibrary/issues/335

This PR allows iiif_print to support iiif external image servers

# Screenshots / Video
![Screenshot 2023-03-23 at 09 49 57](https://user-images.githubusercontent.com/10081604/227322534-9ed5d87b-608f-4106-b22a-f59de258861c.png)



# Expected Behavior
- [ ] All files should get served from cloudfront instead of the rails app.

# TODO: 

There's a loading issue in dev; when we change code the app no longer hits our iiif_manifest_presenter_behavior.rb it reverts back to using the app instead of cloudfront. This seems to only impact dev but it's really annoying. 

We also added the DisplayImagePresenterBehavior prepend in the after_intitialize because the app couldn't find the digest method otherwise.

We will also need to figure out how to make serverless iiif work for audio/video files.