### PR TITLE
Remove canvas sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ IiifPrint supports:
 * OCR keyword match highlighting
 * viewer with page navigation and deep zooming
 * splitting of PDFs to LZW compressed TIFFs for viewing
-* configuring how the manifest canvases are sorted in the viewer
 * adding metadata fields to the manifest with faceted search links and external links
 * excluding specified work types to be found in the catalog search
 
@@ -123,10 +122,6 @@ IiifPrint.config do |config|
   # Add configurable solr field key for searching, default key is: 'human_readable_type_sim' if
   # another key is used, make sure to adjust the config.excluded_model_name_solr_field_values to match
   config.excluded_model_name_solr_field_key = 'some_solr_field_key'
-
-  # Configure how the manifest sorts the canvases, by default it sorts by `:title`, but a different
-  # model property may be desired such as :date_published
-  config.sort_iiif_manifest_canvases_by = :date_published
 end
 ```
 
@@ -153,7 +148,7 @@ TO ENABLE OCR Search (from the UV and catalog search)
     }
 ```
 
-To remove child works from recent works on homepage 
+To remove child works from recent works on homepage
 ### homepage_controller.rb
 * In the HomepageController, change the search_builder_class to remove works from recent_documents if `is_child_bsi: true`
 ```rb

--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -41,8 +41,6 @@ module IiifPrint
       manifest = manifest_factory.new(presenter).to_h
       hash = JSON.parse(manifest.to_json)
       hash = send("sanitize_v#{@version}", hash: hash, presenter: presenter)
-      return send("sort_canvases_v#{@version}", hash: hash, sort_field: IiifPrint.config.sort_iiif_manifest_canvases_by) if @child_works.present?
-
       hash
     end
 
@@ -78,32 +76,6 @@ module IiifPrint
 
       canvas_metadata = IiifPrint.manifest_metadata_from(work: image, presenter: presenter)
       canvas['metadata'] = canvas_metadata
-    end
-
-    LARGEST_SORT_ORDER_CHAR = '~'.freeze
-
-    def sort_canvases_v2(hash:, sort_field:)
-      sort_field = Hyrax::Renderers::AttributeRenderer.new(sort_field, nil).label
-      hash['sequences']&.first&.[]('canvases')&.sort_by! do |canvas|
-        selection = canvas['metadata'].select { |h| h['label'] == sort_field }
-        fallback = [{ label: sort_field,
-                      value: [LARGEST_SORT_ORDER_CHAR] }]
-        sort_field_metadata = selection.presence || fallback
-        sort_field_metadata.first['value'] if sort_field_metadata.present?
-      end
-      hash
-    end
-
-    def sort_canvases_v3(hash:, sort_field:)
-      sort_field = Hyrax::Renderers::AttributeRenderer.new(sort_field, nil).label
-      hash['items']&.sort_by! do |item|
-        selection = item['metadata'].select { |h| h['label'][I18n.locale.to_s] == [sort_field] }
-        fallback = [{ label: { "#{I18n.locale}": [sort_field] },
-                      value: { none: [LARGEST_SORT_ORDER_CHAR] } }]
-        sort_field_metadata = selection.presence || fallback
-        sort_field_metadata.first['value']['none'] if sort_field_metadata.present?
-      end
-      hash
     end
 
     def member_ids_for(presenter)

--- a/lib/generators/iiif_print/templates/config/initializers/iiif_print.rb
+++ b/lib/generators/iiif_print/templates/config/initializers/iiif_print.rb
@@ -14,9 +14,4 @@ IiifPrint.config do |config|
   # config.excluded_model_name_solr_field_values to match
   # @example
   #   config.excluded_model_name_solr_field_key = 'some_solr_field_key'
-
-  # Configure how the manifest sorts the canvases, by default it sorts by :title,
-  # but a different model property may be desired such as :date_published
-  # @example
-  #   config.sort_iiif_manifest_canvases_by = :date_published
 end

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -81,11 +81,6 @@ module IiifPrint
     end
     # rubocop:enable Metrics/MethodLength
 
-    attr_writer :sort_iiif_manifest_canvases_by
-    def sort_iiif_manifest_canvases_by
-      @sort_iiif_manifest_canvases_by || :title
-    end
-
     attr_writer :additional_tessearct_options
     ##
     # The additional options to pass to the Tesseract configuration

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -14,17 +14,6 @@ RSpec.describe IiifPrint::Configuration do
     end
   end
 
-  describe "#sort_iiif_manifest_canvases_by" do
-    subject { config.sort_iiif_manifest_canvases_by }
-
-    it { is_expected.to be_a Symbol }
-    it "allows for an override" do
-      original = config.sort_iiif_manifest_canvases_by
-      config.sort_iiif_manifest_canvases_by = :title
-      expect(config.metadata_fields).not_to eq original
-    end
-  end
-
   describe "#handle_after_create_fileset" do
     let(:file_set) { double(FileSet) }
     let(:user) { double(User) }


### PR DESCRIPTION
Now that ordered members are sorted in order, the custom sort is no longer needed.  UV sorting will also follow ordered member sorting so the items partial and the UV will always be in sync.

ref: https://github.com/scientist-softserv/iiif_print/commit/e3384284a9992df867b7bedc256c82485355551d