### PR TITLE
Add `OMP_THREAD_LIMIT=1` to tesseract call

### DIFF
--- a/lib/iiif_print/text_extraction/page_ocr.rb
+++ b/lib/iiif_print/text_extraction/page_ocr.rb
@@ -22,7 +22,7 @@ module IiifPrint
 
       def run_ocr
         outfile = File.join(Dir.mktmpdir, 'output_html')
-        cmd = "tesseract #{path} #{outfile}"
+        cmd = "OMP_THREAD_LIMIT=1 tesseract #{path} #{outfile}"
         cmd += " #{@additional_tessearct_options}" if @additional_tessearct_options.present?
         cmd += " hocr"
         `#{cmd}`


### PR DESCRIPTION
ref: #203 

Taking a page out of IU's book, they prepend `OMP_THREAD_LIMIT=1` to their tesseract calls.  This would improve performance in a multithreaded deployed environment.

ref: https://github.com/IU-Libraries-Joint-Development/essi/blob/a8a48da218e1084b13d250edf287eb6d1811d92c/app/services/processors/ocr.rb#L14