### PR TITLE
Extracting ancestry identifier configurability

### DIFF
--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -12,6 +12,14 @@ module IiifPrint
       end
     end
 
+    attr_writer :ancestory_identifier_function
+    # The function, with arity 1, that receives a work and returns it's identifier for the purposes
+    # of object ancestry.
+    # @return [Proc]
+    def ancestory_identifier_function
+      @ancestory_identifier_function ||= ->(work) { work.id }
+    end
+
     attr_writer :excluded_model_name_solr_field_values
     # By default, this uses an array of human readable types
     #   ex: ['Generic Work', 'Image']

--- a/lib/iiif_print/lineage_service.rb
+++ b/lib/iiif_print/lineage_service.rb
@@ -18,10 +18,21 @@ module IiifPrint
     def self.ancestor_ids_for(object)
       ancestor_ids ||= []
       object.in_works.each do |work|
-        ancestor_ids << work.id
+        ancestor_ids << ancestry_identifier_for(work)
         ancestor_ids += ancestor_ids_for(work) if work.is_child
       end
       ancestor_ids.flatten.compact.uniq
+    end
+
+    ##
+    # @api public
+    #
+    # Given the :work return it's identifier
+    #
+    # @param [Object]
+    # @return [String]
+    def self.ancestry_identifier_for(work)
+      IiifPrint.config.ancestory_identifier_function.call(work)
     end
 
     ##

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -3,6 +3,19 @@ require 'spec_helper'
 RSpec.describe IiifPrint::Configuration do
   let(:config) { described_class.new }
 
+  describe '#ancestory_identifier_function' do
+    subject(:function) { config.ancestory_identifier_function }
+    it "is expected to be a lambda with an arity of one" do
+      expect(function.arity).to eq(1)
+    end
+
+    it "is configurable" do
+      expect do
+        config.ancestory_identifier_function = ->(w) { w.object_id }
+      end.to change { config.ancestory_identifier_function.object_id }
+    end
+  end
+
   describe "#metadata_fields" do
     subject { config.metadata_fields }
 


### PR DESCRIPTION
Prior to this commit, we assumed that a work's `id` was the mechanism for always identifying a work in regards to it's ancestry/lineage.

However, for implmentations that incorproate slug behavior, that reality is not always the case.

With this commit, we expose a configurable mechanism for altering the ancestry functionality.

Related to:

- https://github.com/scientist-softserv/adventist-dl/pull/354/
- https://github.com/scientist-softserv/adventist-dl/issues/319