### PR TITLE
Adding child_file_title_generator_function

### DIFF
--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -29,14 +29,27 @@ module IiifPrint
       @excluded_model_name_solr_field_values = []
     end
 
-    attr_writer :child_title_generator_function # The function, with 6 keywords (though maybe you'll want to splat ignore a few), is responsible for generating the child work file title.
-    # of object ancestry.
+    attr_writer :child_title_generator_function
+
+    # The function, with keywords (though maybe you'll want to splat ignore a few), is responsible
+    # for generating the child work file title.  of object ancestry.
+    #
+    # The keyword parameters that will be passed to this function are:
+    #
+    # :original_pdf_path - The fully qualified pathname to the original PDF from which the images
+    #                      were split.
+    # :image_path - The fully qualified pathname for an image of the single page from the PDF.
+    # :parent_work - The object in which we're "attaching" the image.
+    # :page_number - The image is of the N-th page_number of the original PDF
+    # :page_padding - A helper number that indicates the number of significant digits of pages
+    #                 (e.g. 150 pages would have a padding of 3).
+    #
     # @return [Proc]
     # rubocop:disable Lint/UnusedBlockArgument
     def child_title_generator_function
-      @child_title_generator_function ||= lambda { |file_path:, parent_work:, page_number:, page_padding:|
+      @child_title_generator_function ||= lambda { |original_pdf_path:, image_path:, parent_work:, page_number:, page_padding:|
         identifier = parent_work.id
-        filename = File.basename(file_path)
+        filename = File.basename(original_pdf_path)
         page_suffix = "Page #{(page_number.to_i + 1).to_s.rjust(page_padding.to_i, '0')}"
         "#{identifier} - #{filename} #{page_suffix}"
       }

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -29,12 +29,12 @@ module IiifPrint
       @excluded_model_name_solr_field_values = []
     end
 
-    attr_writer :child_file_title_generator_function
-    # The function, with arity 5, is responsible for generating the child work file title.
+    attr_writer :child_file_title_generator_function # The function, with 6 keywords (though maybe you'll want to splat ignore a few), is responsible for generating the child work file title.
     # of object ancestry.
     # @return [Proc]
+    # rubocop:disable Lint/UnusedBlockArgument
     def child_file_title_generator_function
-      @child_file_title_generator_function ||= ->(parent_work:, pdf_number:, page_number:, pdf_padding:, page_padding:) {
+      @child_file_title_generator_function ||= lambda { |file_path:, parent_work:, pdf_number:, page_number:, pdf_padding:, page_padding:|
         title = Array(parent_work.title).first
         pdf_nbr = (pdf_number.to_i + 1).to_s.rjust(pdf_padding.to_i, "0")
         page_nbr = (page_number.to_i + 1).to_s.rjust(page_padding.to_i, "0")
@@ -43,6 +43,7 @@ module IiifPrint
         "#{title}: #{pdf_index}, #{page_number}"
       }
     end
+    # rubocop:enable Lint/UnusedBlockArgument
 
     # This method wraps Hyrax's configuration so we can sniff out the correct method to use.  The
     # {Hyrax::Configuration#whitelisted_ingest_dirs} is deprecated in favor of

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -29,7 +29,7 @@ module IiifPrint
       @excluded_model_name_solr_field_values = []
     end
 
-    attr_writer :child_title_generator_function
+    attr_writer :unique_child_title_generator_function
 
     # The function, with keywords (though maybe you'll want to splat ignore a few), is responsible
     # for generating the child work file title.  of object ancestry.
@@ -46,8 +46,8 @@ module IiifPrint
     #
     # @return [Proc]
     # rubocop:disable Lint/UnusedBlockArgument
-    def child_title_generator_function
-      @child_title_generator_function ||= lambda { |original_pdf_path:, image_path:, parent_work:, page_number:, page_padding:|
+    def unique_child_title_generator_function
+      @unique_child_title_generator_function ||= lambda { |original_pdf_path:, image_path:, parent_work:, page_number:, page_padding:|
         identifier = parent_work.id
         filename = File.basename(original_pdf_path)
         page_suffix = "Page #{(page_number.to_i + 1).to_s.rjust(page_padding.to_i, '0')}"

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -29,6 +29,21 @@ module IiifPrint
       @excluded_model_name_solr_field_values = []
     end
 
+    attr_writer :child_file_title_generator_function
+    # The function, with arity 5, is responsible for generating the child work file title.
+    # of object ancestry.
+    # @return [Proc]
+    def child_file_title_generator_function
+      @child_file_title_generator_function ||= ->(parent_work:, pdf_number:, page_number:, pdf_padding:, page_padding:) {
+        title = Array(parent_work.title).first
+        pdf_nbr = (pdf_number.to_i + 1).to_s.rjust(pdf_padding.to_i, "0")
+        page_nbr = (page_number.to_i + 1).to_s.rjust(page_padding.to_i, "0")
+        pdf_index = "Pdf #{pdf_nbr}"
+        page_number = "Page #{page_nbr}"
+        "#{title}: #{pdf_index}, #{page_number}"
+      }
+    end
+
     # This method wraps Hyrax's configuration so we can sniff out the correct method to use.  The
     # {Hyrax::Configuration#whitelisted_ingest_dirs} is deprecated in favor of
     # {Hyrax::Configuration#registered_ingest_dirs}.

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -37,7 +37,7 @@ module IiifPrint
       @child_title_generator_function ||= lambda { |file_path:, parent_work:, page_number:, page_padding:|
         identifier = parent_work.id
         filename = File.basename(file_path)
-        page_suffix = "Page #{(page_number.to_i + 1).to_s.rjust(page_padding.to_i, "0")}"
+        page_suffix = "Page #{(page_number.to_i + 1).to_s.rjust(page_padding.to_i, '0')}"
         "#{identifier} - #{filename} #{page_suffix}"
       }
     end

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -29,18 +29,16 @@ module IiifPrint
       @excluded_model_name_solr_field_values = []
     end
 
-    attr_writer :child_file_title_generator_function # The function, with 6 keywords (though maybe you'll want to splat ignore a few), is responsible for generating the child work file title.
+    attr_writer :child_title_generator_function # The function, with 6 keywords (though maybe you'll want to splat ignore a few), is responsible for generating the child work file title.
     # of object ancestry.
     # @return [Proc]
     # rubocop:disable Lint/UnusedBlockArgument
-    def child_file_title_generator_function
-      @child_file_title_generator_function ||= lambda { |file_path:, parent_work:, pdf_number:, page_number:, pdf_padding:, page_padding:|
-        title = Array(parent_work.title).first
-        pdf_nbr = (pdf_number.to_i + 1).to_s.rjust(pdf_padding.to_i, "0")
-        page_nbr = (page_number.to_i + 1).to_s.rjust(page_padding.to_i, "0")
-        pdf_index = "Pdf #{pdf_nbr}"
-        page_number = "Page #{page_nbr}"
-        "#{title}: #{pdf_index}, #{page_number}"
+    def child_title_generator_function
+      @child_title_generator_function ||= lambda { |file_path:, parent_work:, page_number:, page_padding:|
+        identifier = parent_work.id
+        filename = File.basename(file_path)
+        page_suffix = "Page #{(page_number.to_i + 1).to_s.rjust(page_padding.to_i, "0")}"
+        "#{identifier} - #{filename} #{page_suffix}"
       }
     end
     # rubocop:enable Lint/UnusedBlockArgument

--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -70,7 +70,7 @@ module IiifPrint
         image_files.each_with_index do |image_path, page_number|
           file_id = create_uploaded_file(user, image_path).to_s
 
-          child_title = IiifPrint.config.child_title_generator_function.call(
+          child_title = IiifPrint.config.unique_child_title_generator_function.call(
             original_pdf_path: original_pdf_path,
             image_path: image_path,
             parent_work: @parent_work,
@@ -83,15 +83,10 @@ module IiifPrint
           # save child work info to create the member relationships
           PendingRelationship.create!(child_title: child_title,
                                       parent_id: @parent_work.id,
-                                      child_order: sort_order(page_number,
-                                                              page_pad_zero: number_of_digits(nbr: number_of_pages_in_pdf)))
+                                      child_order: child_title)
         end
       end
       # rubocop:enable Metrics/MethodLength
-
-      def sort_order(page_number, page_pad_zero:)
-        (page_number + 1).to_s.rjust(page_pad_zero, "0")
-      end
 
       def number_of_digits(nbr:)
         nbr.to_s.size

--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -70,11 +70,19 @@ module IiifPrint
         pdf_number_of_pages = image_files.size
         image_files.each_with_index do |image_path, idx|
           file_id = create_uploaded_file(user, image_path).to_s
-          file_title = set_title(@parent_work.title.first,
-                                 pdf_sequence,
-                                 idx,
-                                 pdf_pad_zero: number_of_digits(nbr: number_of_pdfs),
-                                 page_pad_zero: number_of_digits(nbr: pdf_number_of_pages))
+
+          file_title = Iiif.config.child_file_title_generator_function.call(
+            parent_work: parent_work,
+            pdf_number: pdf_sequence,
+            page_number: idx,
+            pdf_padding: number_of_digits(nbr: number_of_pdfs),
+            page_padding: number_of_digits(nbr: pdf_number_of_pages))
+
+          # file_title = set_title(@parent_work.title.first,
+          #                        pdf_sequence,
+          #                        idx,
+          #                        pdf_pad_zero: number_of_digits(nbr: number_of_pdfs),
+          #                        page_pad_zero: number_of_digits(nbr: pdf_number_of_pages))
           @uploaded_files << file_id
           @child_work_titles[file_id] = file_title
           # save child work info to create the member relationships

--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -70,7 +70,7 @@ module IiifPrint
         image_files.each_with_index do |image_path, page_number|
           file_id = create_uploaded_file(user, image_path).to_s
 
-          child_title = Iiif.config.child_title_generator_function.call(
+          child_title = IiifPrint.config.child_title_generator_function.call(
             file_path: image_path,
             parent_work: parent_work,
             page_number: page_number,

--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -72,7 +72,7 @@ module IiifPrint
 
           child_title = IiifPrint.config.child_title_generator_function.call(
             file_path: image_path,
-            parent_work: parent_work,
+            parent_work: @parent_work,
             page_number: page_number,
             page_padding: number_of_digits(nbr: number_of_pages_in_pdf)
           )

--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -71,19 +71,17 @@ module IiifPrint
         image_files.each_with_index do |image_path, idx|
           file_id = create_uploaded_file(user, image_path).to_s
 
-          file_title = Iiif.config.child_file_title_generator_function.call(
-            image_path: image_path,
+          child_title = Iiif.config.child_title_generator_function.call(
+            file_path: image_path,
             parent_work: parent_work,
-            pdf_number: pdf_sequence,
             page_number: idx,
-            pdf_padding: number_of_digits(nbr: number_of_pdfs),
             page_padding: number_of_digits(nbr: pdf_number_of_pages)
           )
 
           @uploaded_files << file_id
-          @child_work_titles[file_id] = file_title
+          @child_work_titles[file_id] = child_title
           # save child work info to create the member relationships
-          PendingRelationship.create!(child_title: file_title,
+          PendingRelationship.create!(child_title: child_title,
                                       parent_id: @parent_work.id,
                                       child_order: sort_order(pdf_sequence,
                                                               idx,

--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -72,17 +72,14 @@ module IiifPrint
           file_id = create_uploaded_file(user, image_path).to_s
 
           file_title = Iiif.config.child_file_title_generator_function.call(
+            image_path: image_path,
             parent_work: parent_work,
             pdf_number: pdf_sequence,
             page_number: idx,
             pdf_padding: number_of_digits(nbr: number_of_pdfs),
-            page_padding: number_of_digits(nbr: pdf_number_of_pages))
+            page_padding: number_of_digits(nbr: pdf_number_of_pages)
+          )
 
-          # file_title = set_title(@parent_work.title.first,
-          #                        pdf_sequence,
-          #                        idx,
-          #                        pdf_pad_zero: number_of_digits(nbr: number_of_pdfs),
-          #                        page_pad_zero: number_of_digits(nbr: pdf_number_of_pages))
           @uploaded_files << file_id
           @child_work_titles[file_id] = file_title
           # save child work info to create the member relationships
@@ -112,15 +109,6 @@ module IiifPrint
         uf.file = CarrierWave::SanitizedFile.new(path)
         uf.save!
         uf.id
-      end
-
-      def set_title(title, pdf_sequence, idx, pdf_pad_zero:, page_pad_zero:)
-        # TODO: prior_pdfs may cause issues in the future
-        pdf_nbr = (pdf_sequence + 1).to_s.rjust(pdf_pad_zero, "0")
-        page_nbr = (idx + 1).to_s.rjust(page_pad_zero, "0")
-        pdf_index = "Pdf #{pdf_nbr}"
-        page_number = "Page #{page_nbr}"
-        "#{title}: #{pdf_index}, #{page_number}"
       end
 
       # TODO: what attributes do we need to fill in from the parent work? What about AllinsonFlex?

--- a/lib/iiif_print/split_pdfs/child_work_creation_from_pdf_service.rb
+++ b/lib/iiif_print/split_pdfs/child_work_creation_from_pdf_service.rb
@@ -37,17 +37,17 @@ module IiifPrint
       end
 
       # Submit the job to split PDF into child works
-      # @param [GenericWork, etc] A valid type of hyrax work
-      # @param [Array<String>] paths to PDF attachments
-      # @param [User] user
-      # @param [Integer] number of pdfs already on existing work's filesets (not yet implemented)
+      # @param work [GenericWork, etc] A valid type of hyrax work
+      # @param file_locations [Array<String>] paths to PDF attachments
+      # @param user [User] user
+      # @param admin_set_id [String]
       def self.queue_job(work:, file_locations:, user:, admin_set_id:)
         work.iiif_print_config.pdf_splitter_job.perform_later(
           work,
           file_locations,
           user,
           admin_set_id,
-          count_existing_pdfs(work)
+          0 # A no longer used parameter; but we need to preserve the method signature (for now)
         )
       end
 
@@ -58,13 +58,9 @@ module IiifPrint
       # Given Hyrax::Upload object, return path to file on local filesystem
       def self.upload_path(upload)
         # so many layers to this onion:
+        # TODO: Write a recursive function to keep calling file until
+        # the file doesn't respond to file then return that file.
         upload.file.file.file
-      end
-
-      # TODO: implement a method to count existing PDFs on a work to support
-      #       adding more PDFs to an existing work.
-      def self.count_existing_pdfs(_work)
-        0
       end
 
       # TODO: Consider other methods to identify a PDF file.

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe IiifPrint::Configuration do
     end
   end
 
-  describe '#child_title_generator_function' do
-    subject(:function) { config.child_title_generator_function }
+  describe '#unique_child_title_generator_function' do
+    subject(:function) { config.unique_child_title_generator_function }
 
     it "is expected to be a lambda with keyword args" do
       expect(function.parameters).to eq([[:keyreq, :original_pdf_path],
@@ -40,8 +40,8 @@ RSpec.describe IiifPrint::Configuration do
 
     it "is configurable" do
       expect do
-        config.child_title_generator_function = ->(**kwargs) { kwargs }
-      end.to change { config.child_title_generator_function.object_id }
+        config.unique_child_title_generator_function = ->(**kwargs) { kwargs }
+      end.to change { config.unique_child_title_generator_function.object_id }
     end
   end
 

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -16,6 +16,34 @@ RSpec.describe IiifPrint::Configuration do
     end
   end
 
+  describe '#child_file_title_generator_function' do
+    subject(:function) { config.child_file_title_generator_function }
+
+    it "is expected to be a lambda with keyword args" do
+      expect(function.parameters).to eq([[:keyreq, :parent_work],
+                                         [:keyreq, :pdf_number],
+                                         [:keyreq, :page_number],
+                                         [:keyreq, :pdf_padding],
+                                         [:keyreq, :page_padding]])
+    end
+
+    it 'works as originally designed' do
+      work = double(title: ["My Title"])
+      expect(function.call(
+               parent_work: work,
+               pdf_number: 1,
+               page_number: 23,
+               pdf_padding: 3,
+               page_padding: 5)).to eq("My Title: Pdf 002, Page 00024")
+    end
+
+    it "is configurable" do
+      expect do
+        config.child_file_title_generator_function = ->(**kwargs) { kwargs }
+      end.to change { config.child_file_title_generator_function.object_id }
+    end
+  end
+
   describe "#metadata_fields" do
     subject { config.metadata_fields }
 

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -16,33 +16,30 @@ RSpec.describe IiifPrint::Configuration do
     end
   end
 
-  describe '#child_file_title_generator_function' do
-    subject(:function) { config.child_file_title_generator_function }
+  describe '#child_title_generator_function' do
+    subject(:function) { config.child_title_generator_function }
 
     it "is expected to be a lambda with keyword args" do
       expect(function.parameters).to eq([[:keyreq, :file_path],
                                          [:keyreq, :parent_work],
-                                         [:keyreq, :pdf_number],
                                          [:keyreq, :page_number],
-                                         [:keyreq, :pdf_padding],
                                          [:keyreq, :page_padding]])
     end
 
     it 'works as originally designed' do
-      work = double(title: ["My Title"])
+      work = double(title: ["My Title"], id: '1234')
       expect(function.call(
+               file_path: __FILE__,
                parent_work: work,
-               pdf_number: 1,
                page_number: 23,
-               pdf_padding: 3,
                page_padding: 5
-             )).to eq("My Title: Pdf 002, Page 00024")
+             )).to eq("1234 - configuration_spec.rb Page 00024")
     end
 
     it "is configurable" do
       expect do
-        config.child_file_title_generator_function = ->(**kwargs) { kwargs }
-      end.to change { config.child_file_title_generator_function.object_id }
+        config.child_title_generator_function = ->(**kwargs) { kwargs }
+      end.to change { config.child_title_generator_function.object_id }
     end
   end
 

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe IiifPrint::Configuration do
     subject(:function) { config.child_title_generator_function }
 
     it "is expected to be a lambda with keyword args" do
-      expect(function.parameters).to eq([[:keyreq, :file_path],
+      expect(function.parameters).to eq([[:keyreq, :original_pdf_path],
+                                         [:keyreq, :image_path],
                                          [:keyreq, :parent_work],
                                          [:keyreq, :page_number],
                                          [:keyreq, :page_padding]])
@@ -29,11 +30,12 @@ RSpec.describe IiifPrint::Configuration do
     it 'works as originally designed' do
       work = double(title: ["My Title"], id: '1234')
       expect(function.call(
-               file_path: __FILE__,
+               original_pdf_path: "/hello/world/nice.pdf",
+               image_path: __FILE__,
                parent_work: work,
                page_number: 23,
                page_padding: 5
-             )).to eq("1234 - configuration_spec.rb Page 00024")
+             )).to eq("1234 - nice.pdf Page 00024")
     end
 
     it "is configurable" do

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe IiifPrint::Configuration do
     subject(:function) { config.child_file_title_generator_function }
 
     it "is expected to be a lambda with keyword args" do
-      expect(function.parameters).to eq([[:keyreq, :parent_work],
+      expect(function.parameters).to eq([[:keyreq, :file_path],
+                                         [:keyreq, :parent_work],
                                          [:keyreq, :pdf_number],
                                          [:keyreq, :page_number],
                                          [:keyreq, :pdf_padding],
@@ -34,7 +35,8 @@ RSpec.describe IiifPrint::Configuration do
                pdf_number: 1,
                page_number: 23,
                pdf_padding: 3,
-               page_padding: 5)).to eq("My Title: Pdf 002, Page 00024")
+               page_padding: 5
+             )).to eq("My Title: Pdf 002, Page 00024")
     end
 
     it "is configurable" do


### PR DESCRIPTION
## Adding child_file_title_generator_function

0d88a021ae038a27996bfd4cbc6c8f623a4aac91

Prior to this commit, we had a hard-coding approach to configuring a
child work's title.

With this commit, we preserve the existing behavior (for better or
worse) but expose a configuration option to help in the process
generation.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/204

## Removing dead code

e83f70a5ea0064bcb4a07bdc81d2693397dba775


## Refactoring internal method for Child Work title

ac0b5edfb7fa21b234f067ad796a0eab4e1bed67

Based on feedback from clients and process improvements, this is a
change that will help ensure more unique titles; and make a visiual
connection to the PDF that child works were generated from.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/204

## Removing private variables no longer needed

d435eeb0622a46364eb48d0a7add8a1e0517f1ea

This commit includes a deprecation documentation, a bit of recursive
humor, and removal of variables and parameters that are no longer
necessary based on the updated child work title function.
