### PR TITLE
Add guard to method

### DIFF
--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -68,13 +68,12 @@ module IiifPrint
 
     def apply_metadata_to_canvas(canvas:, presenter:)
       return if @child_works.empty?
-
       parent_and_child_solr_hits = parent_and_child_solr_hits(presenter)
       # uses the 'id' property for v3 manifest and `@id' for v2, which is a URL that contains the FileSet id
       file_set_id = (canvas['id'] || canvas['@id']).split('/').last
       # finds the image that the FileSet is attached to and creates metadata on that canvas
       image = parent_and_child_solr_hits.find { |doc| doc[:member_ids_ssim]&.include?(file_set_id) }
-
+      return unless image
       canvas_metadata = IiifPrint.manifest_metadata_from(work: image, presenter: presenter)
       canvas['metadata'] = canvas_metadata
     end


### PR DESCRIPTION
This is an edge case, but prevents a manifest failure. Previously we got an error because of calling `IiifPrint.manifest_metadata_from(work: image, presenter: presenter)` when image was nil.

<details>
<summary> Before & After Screenshots</summary>

**Before:**

![Screenshot 2023-04-07 at 11 44 42 AM](https://user-images.githubusercontent.com/17851674/230637880-6efb8336-80b3-468c-8ca0-2e2e32f92a5e.png)

**After:**

![Screenshot 2023-04-07 at 11 43 32 AM](https://user-images.githubusercontent.com/17851674/230637921-c0ca6424-b493-4e69-8ea6-2649b480e996.png)

</details>

### Testing Instructions

1. Add a new work with an image file.
2. When viewing the above work, add a child work as a child using the `Attach Child` dropdown option. Use a PDF file for this child's file.
3. When returning to the original work, universal viewer should show both the original image and all of the child work's split child work images.