### PR TITLE
Renaming method for clarity for a confusing reality

### DIFF
--- a/app/indexers/concerns/iiif_print/child_indexer.rb
+++ b/app/indexers/concerns/iiif_print/child_indexer.rb
@@ -27,7 +27,12 @@ module IiifPrint
       super.tap do |solr_doc|
         solr_doc['is_child_bsi'] = object.is_child
         solr_doc['is_page_of_ssim'] = iiif_print_lineage_service.ancestor_ids_for(object)
-        solr_doc['file_set_ids_ssim'] = iiif_print_lineage_service.descendent_file_set_ids_for(object)
+
+        # Due to a long-standing hack in Hyrax, the file_set_ids_ssim contains both file_set_ids and
+        # child work ids.
+        #
+        # See https://github.com/samvera/hyrax/blob/2b807fe101176d594129ef8a8fe466d3d03a372b/app/indexers/hyrax/work_indexer.rb#L15-L18
+        solr_doc['file_set_ids_ssim'] = iiif_print_lineage_service.descendent_member_ids_for(object)
       end
     end
   end

--- a/lib/iiif_print/lineage_service.rb
+++ b/lib/iiif_print/lineage_service.rb
@@ -55,6 +55,8 @@ module IiifPrint
       end
       file_set_ids.flatten.uniq.compact
     end
-    alias descendent_file_set_ids_for descendent_member_ids_for
+    class << self
+      alias descendent_file_set_ids_for descendent_member_ids_for
+    end
   end
 end

--- a/spec/iiif_print/lineage_service_spec.rb
+++ b/spec/iiif_print/lineage_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IiifPrint::LineageService do
     xit 'works'
   end
 
-  describe '.descendent_file_set_ids_for' do
+  describe '.descendent_member_ids_for' do
     xit 'works'
   end
 end


### PR DESCRIPTION
Prior to this commit, we had a method that returned unexpected values, in part because upstream behaves unexpected.

Due to a long-standing hack in Hyrax, the file_set_ids_ssim contains both file_set_ids and child work ids.

The Hydara::Works implementation of file_set_ids is `members.select(&:file_set?).map(&:id)`; so no sense doing `object.file_set_ids + object.member_ids`

See
https://github.com/samvera/hyrax/blob/2b807fe101176d594129ef8a8fe466d3d03a372b/app/indexers/hyrax/work_indexer.rb#L15-L18

With this commit, we're both simplifying the logic, and clarifying the behavior by renaming the method (and preserving the existing method name for those who like obfuscation).
