### PR TITLE
Catalog to uv search

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,31 @@ IiifPrint easily integrates with your Hyrax 2.x applications.
 
 (It may be helpful to run `git diff` after installation to see all the changes made by the installer.)
 
+## Catalog to Universal Viewer search:
+To enable a feature where the UV automatically picks up the search from the catalog, do the following:
+* Add `highlight: urlDataProvider.get('q'),` into your uv.html in the `<script>` section.
+```js
+uv = createUV('#uv', {
+    root: '.',
+    iiifResourceUri: urlDataProvider.get('manifest'),
+    configUri: 'uv-config.json',
+    collectionIndex: Number(urlDataProvider.get('c', 0)),
+    manifestIndex: Number(urlDataProvider.get('m', 0)),
+    sequenceIndex: Number(urlDataProvider.get('s', 0)),
+    canvasIndex: Number(urlDataProvider.get('cv', 0)),
+    rangeId: urlDataProvider.get('rid', 0),
+    rotation: Number(urlDataProvider.get('r', 0)),
+    xywh: urlDataProvider.get('xywh', ''),
+    embedded: true,
+    highlight: urlDataProvider.get('q'), // <-- here's a good spot
+    locales: formattedLocales
+}, urlDataProvider);
+```
+
+* Make sure to remove your application's `app/helpers/hyrax/iiif_helper.rb` and `app/views/hyrax/base/iiif_viewers
+/_universal_viewer.html.erb` (if exists)
+
+
 ## Configuration to enable IiifPrint features
 **NOTE: WorkTypes and models are used synonymously here.**
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,7 @@ uv = createUV('#uv', {
 }, urlDataProvider);
 ```
 
-* Make sure to remove your application's `app/helpers/hyrax/iiif_helper.rb` and `app/views/hyrax/base/iiif_viewers
-/_universal_viewer.html.erb` (if exists)
-
+* Make sure to remove your application's `app/helpers/hyrax/iiif_helper.rb` and `app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb` (if exists)
 
 ## Configuration to enable IiifPrint features
 **NOTE: WorkTypes and models are used synonymously here.**

--- a/app/helpers/iiif_print/iiif_helper_decorator.rb
+++ b/app/helpers/iiif_print/iiif_helper_decorator.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-module Hyrax
-  module IiifHelper
+# OVERRIDE Hyrax v2.9.6 add #uv_search_param
+
+module IiifPrint
+  module IiifHelperDecorator
     def iiif_viewer_display(work_presenter, locals = {})
       render iiif_viewer_display_partial(work_presenter),
              locals.merge(presenter: work_presenter)
@@ -17,6 +19,14 @@ module Hyrax
 
     def universal_viewer_config_url
       "#{request&.base_url}/uv/uv-config.json"
+    end
+
+    # Extract query param from search
+    def uv_search_param
+      search_params = current_search_session.try(:query_params) || {}
+      q = search_params['q'].presence || ''
+
+      "&q=#{url_encode(q)}" if q.present?
     end
   end
 end

--- a/app/helpers/iiif_print/iiif_helper_decorator.rb
+++ b/app/helpers/iiif_print/iiif_helper_decorator.rb
@@ -14,11 +14,11 @@ module IiifPrint
     end
 
     def universal_viewer_base_url
-      "#{request&.base_url}/uv/uv.html"
+      "#{request&.base_url}#{IiifPrint.config.uv_base_path}"
     end
 
     def universal_viewer_config_url
-      "#{request&.base_url}/uv/uv-config.json"
+      "#{request&.base_url}#{IiifPrint.config.uv_config_path}"
     end
 
     # Extract query param from search

--- a/app/models/concerns/iiif_print/solr/document.rb
+++ b/app/models/concerns/iiif_print/solr/document.rb
@@ -49,4 +49,8 @@ module IiifPrint::Solr::Document
   def file_set_ids
     self['file_set_ids_ssim']
   end
+
+  def has_any_highlighting?
+    response&.[]('highlighting')&.[](self.id)&.present?
+  end
 end

--- a/app/models/concerns/iiif_print/solr/document.rb
+++ b/app/models/concerns/iiif_print/solr/document.rb
@@ -50,7 +50,7 @@ module IiifPrint::Solr::Document
     self['file_set_ids_ssim']
   end
 
-  def has_any_highlighting?
-    response&.[]('highlighting')&.[](self.id)&.present?
+  def any_highlighting?
+    response&.[]('highlighting')&.[](id)&.present?
   end
 end

--- a/app/models/iiif_print/iiif_search_response_decorator.rb
+++ b/app/models/iiif_print/iiif_search_response_decorator.rb
@@ -4,7 +4,11 @@ module IiifPrint
     # @see https://github.com/scientist-softserv/louisville-hyku/commit/67467e5cf9fdb755f54419f17d3c24c87032d0af
     def annotation_list
       json_results = super
-      json_results&.[]('resources')&.each do |result_hit|
+
+      resources = json_results&.[]('resources')
+      return unless resources
+
+      resources&.each do |result_hit|
         next if result_hit['resource'].present?
         result_hit['resource'] = {
           "@type": "cnt:ContentAsText",

--- a/app/search_builders/concerns/iiif_print/highlight_search_params.rb
+++ b/app/search_builders/concerns/iiif_print/highlight_search_params.rb
@@ -6,9 +6,10 @@ module IiifPrint
     def highlight_search_params(solr_parameters = {})
       return unless solr_parameters[:q] || solr_parameters[:all_fields]
       solr_parameters[:hl] = true
-      solr_parameters[:'hl.fl'] = 'all_text_tsimv'
+      solr_parameters[:'hl.fl'] = '*'
       solr_parameters[:'hl.fragsize'] = 100
       solr_parameters[:'hl.snippets'] = 5
+      solr_parameters[:'hl.requiredFieldMatch'] = true
     end
   end
 end

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,0 +1,13 @@
+<%# OVERRIDE Hyrax 2.9.6 to show parent_query params if metadata is found in parent record %>
+
+<div class="search-results-title-row">
+  <h3 class="search-result-title">
+  <% if params['q'].present? && document.has_any_highlighting? %>
+    <%= link_to document.title_or_label, [document, { parent_query: params['q'] }] %></h3>
+  <% elsif params['q'].present? %>
+    <%= link_to document.title_or_label, [document, { query: params['q'] }] %></h3>
+  <% else %>
+    <%= link_to document.title_or_label, document %></h3>
+  <% end %>
+  </h3>
+</div>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -2,7 +2,7 @@
 
 <div class="search-results-title-row">
   <h3 class="search-result-title">
-  <% if params['q'].present? && document.has_any_highlighting? %>
+  <% if params['q'].present? && document.any_highlighting? %>
     <%= link_to document.title_or_label, [document, { parent_query: params['q'] }] %></h3>
   <% elsif params['q'].present? %>
     <%= link_to document.title_or_label, [document, { query: params['q'] }] %></h3>

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,7 +1,7 @@
 <div class="viewer-wrapper">
   <iframe
     id="uv-iframe"
-    src="<%= universal_viewer_base_url %>#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url %>"
+    src="<%= universal_viewer_base_url %>#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url %><%= uv_search_param %>"
     allowfullscreen="true"
     frameborder="0"
   ></iframe>

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -125,5 +125,21 @@ module IiifPrint
     def additional_tessearct_options
       @additional_tessearct_options || ""
     end
+
+    attr_writer :uv_config_path
+    ##
+    # According to https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#universal-viewer-config
+    # the name of the UV config file should be /uv/uv_config.json (with an _)
+    # However, in most applications, it is /uv/uv-config.json (with a -)
+    def uv_config_path
+      @uv_config_path || "/uv/uv-config.json"
+    end
+
+    attr_writer :uv_base_path
+    ##
+    # While we're at it, we're going to go ahead and make the base path configurable as well
+    def uv_base_path
+      @uv_base_path || "/uv/uv.html"
+    end
   end
 end

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -41,6 +41,7 @@ module IiifPrint
       Hyrax::Renderers::FacetedAttributeRenderer.prepend(Hyrax::Renderers::FacetedAttributeRendererDecorator)
       Hyrax::WorksControllerBehavior.prepend(IiifPrint::WorksControllerBehaviorDecorator)
       Hyrax::WorkShowPresenter.prepend(IiifPrint::WorkShowPresenterDecorator)
+      Hyrax::IiifHelper.prepend(IiifPrint::IiifHelperDecorator)
 
       IiifPrint::ChildIndexer.decorate_work_types!
       IiifPrint::FileSetIndexer.decorate(Hyrax::FileSetIndexer)

--- a/spec/iiif_print/catalog_search_builder_spec.rb
+++ b/spec/iiif_print/catalog_search_builder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe IiifPrint::CatalogSearchBuilder do
     before { subject.highlight_search_params(solr_parameters) }
     it 'adds the highlight fields to solr_parameters' do
       expect(solr_parameters[:hl]).to be_truthy
-      expect(solr_parameters[:'hl.fl']).to eq('all_text_tsimv')
+      expect(solr_parameters[:'hl.fl']).to eq('*')
     end
   end
 


### PR DESCRIPTION
ref: #183

![iiif_print_183](https://user-images.githubusercontent.com/19597776/231897823-e31a31df-a2fd-42db-ab04-7b0473eb167f.gif)

[Add a highlight detection](https://github.com/scientist-softserv/iiif_print/commit/172e13014679ef6f8806e58a69922f96192da49f) 

The `#has_any_highlighting?` method is used to determine if the search
returned any highlighting. If it did, then we add the parent_query to
the search params so that the search results.  This will avoid causing
and No matches found notification in the UV search.  Also in this
commit, we change `hl.fl` to return all fields that are indexed.

---

[Add IIIF Helpers into the load path](https://github.com/scientist-softserv/iiif_print/commit/1250144d026fd58ede24c60456a2808ee25dce13) 

This commit makes the IIIF Helpers work by loading in the engine.rb.
The main reason for the change is the get the #uv_search_param method
usable for the Universal Viewer.  This parameter will automatically get
the user into the search term they were using for the catalog search.

---

[Add catalog to uv search instructions to README](https://github.com/scientist-softserv/iiif_print/commit/0b5b61224a58d7859b57b4e8653e09cedd388e46)

---

[Add configuration for uv config and uv base path](https://github.com/scientist-softserv/iiif_print/commit/575c5e5e330e86ede8f6b188d99c962f70cd8f66) 

This commit will add configuration for the Universal Viewer config and
base path. This solve the problem where some applications use
`uv-config.json` while other maybe use `uv_config.json`.  While we're in
there, we also add a configuration for the Universal Viewer base path.

---

[Add a way to suppress No matches were found](https://github.com/scientist-softserv/iiif_print/commit/78fc6fc787907192be09bd17681f9eaebf642a2e) 

This commit will allow the search to bail if no matches were found
instead of going through an returning no results.