### PR TITLE
Add configuration for child work attributes

### DIFF
--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -141,5 +141,19 @@ module IiifPrint
     def uv_base_path
       @uv_base_path || "/uv/uv.html"
     end
+
+    attr_writer :child_work_attributes_function
+    ##
+    # Here we allow for customization of the child work attributes
+    def child_work_attributes_function
+      @child_work_attributes_function ||= lambda do |parent_work:, admin_set_id:|
+        {
+          admin_set_id: admin_set_id.to_s,
+          creator: parent_work.creator.to_a,
+          rights_statement: parent_work.rights_statement.to_a,
+          visibility: parent_work.visibility.to_s
+        }
+      end
+    end
   end
 end

--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -102,12 +102,7 @@ module IiifPrint
 
       # TODO: what attributes do we need to fill in from the parent work? What about AllinsonFlex?
       def attributes
-        {
-          admin_set_id: @child_admin_set_id.to_s,
-          creator: @parent_work.creator.to_a,
-          rights_statement: @parent_work.rights_statement.to_a,
-          visibility: @parent_work.visibility.to_s
-        }
+        IiifPrint.config.child_work_attributes_function.call(parent_work: @parent_work, admin_set_id: @child_admin_set_id)
       end
     end
   end

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -115,4 +115,13 @@ RSpec.describe IiifPrint::Configuration do
         .to(3)
     end
   end
+
+  describe '#child_work_attributes_function' do
+    subject(:function) { config.child_work_attributes_function }
+
+    it "is expected to be a lambda with keyword args" do
+      expect(function.parameters).to eq([[:keyreq, :parent_work],
+                                         [:keyreq, :admin_set_id]])
+    end
+  end
 end


### PR DESCRIPTION
This commit adds a configuration option for the attributes that are copied from the parent work to the child work. This can allow the child attributes to be more customizable if different projects want different attributes for their child works other what we prescribe.
