### PR TITLE
Omit syntax warnings from command

### DIFF
--- a/lib/iiif_print/split_pdfs/pdf_image_extraction_service.rb
+++ b/lib/iiif_print/split_pdfs/pdf_image_extraction_service.rb
@@ -10,7 +10,7 @@ module IiifPrint
     class PdfImageExtractionService
       def initialize(path)
         @path = path
-        process(command: format('pdfimages -list %<path>s', path: path))
+        process(command: format('pdfimages -list %<path>s 2>/dev/null', path: path))
       end
 
       attr_reader :path, :page_count, :width, :height, :pixels_per_inch


### PR DESCRIPTION
# Story
PDF splitting was locking up during splitting command.

Refs https://github.com/scientist-softserv/britishlibrary/issues/385

# Expected Behavior Before Changes

IiifPrint::Jobs::ChildWorksFromPdfJob hung in sidekiq and had to be cancelled. The file did not get split.

# Expected Behavior After Changes

File now splits correctly but universal viewer breaks due to solr query too large. [This is a new bug ticket.](https://github.com/scientist-softserv/iiif_print/issues/224)

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-04-19 at 4 14 32 PM](https://user-images.githubusercontent.com/17851674/233191480-96395792-548d-4142-8c7d-1ac2a56a28f2.png)
![Screenshot 2023-04-19 at 4 15 10 PM](https://user-images.githubusercontent.com/17851674/233191559-0ef2a076-f19c-419e-9c6f-8c4726c19621.png)
</details>

# Notes