### PR TITLE
revert change that introduced no matches found bug

### DIFF
--- a/app/models/iiif_print/iiif_search_response_decorator.rb
+++ b/app/models/iiif_print/iiif_search_response_decorator.rb
@@ -4,9 +4,7 @@ module IiifPrint
     # @see https://github.com/scientist-softserv/louisville-hyku/commit/67467e5cf9fdb755f54419f17d3c24c87032d0af
     def annotation_list
       json_results = super
-
       resources = json_results&.[]('resources')
-      return unless resources
 
       resources&.each do |result_hit|
         next if result_hit['resource'].present?


### PR DESCRIPTION
# Story

reverts prior change because it causes a bug where the no matches found msg is never returned

# Expected Behavior Before Changes

We implemented this change (in [592537](https://github.com/scientist-softserv/iiif_print/commit/592537f13841f0c6f549f40495d09078cb498127)) as a way to solve: i24 - [Searching for parent metadata leads to error](https://github.com/scientist-softserv/essi/issues/24)

However, it introduced a new bug where now the no matches msg ever displays, even when there aren't any matches.

# Expected Behavior After Changes

If there are no matches from a UV search, a no matches found popup should appear

# Screenshots / Video

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/10081604/233644021-dd645779-a57f-468e-8c27-9c1ad1eb110f.png">

# Notes