### PR TITLE
Sort canvas configuration

### DIFF
--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -1,4 +1,5 @@
 module IiifPrint
+  # rubocop:disable Metrics/ModuleLength
   module ManifestBuilderServiceBehavior
     def initialize(*args,
                    version: IiifPrint.config.default_iiif_manifest_version,
@@ -86,6 +87,8 @@ module IiifPrint
     LARGEST_SORT_ORDER_CHAR = '~'.freeze
 
     def sort_canvases_v2(hash:, sort_field:)
+      return sort_by_label_v2(hash) if sort_field == :label
+
       sort_field = Hyrax::Renderers::AttributeRenderer.new(sort_field, nil).label
       hash['sequences']&.first&.[]('canvases')&.sort_by! do |canvas|
         selection = canvas['metadata'].select { |h| h['label'] == sort_field }
@@ -109,6 +112,14 @@ module IiifPrint
       hash
     end
 
+    # TODO: implement this for v3
+    def sort_by_label_v2(hash)
+      hash['sequences']&.first&.[]('canvases')&.sort_by! do |canvas|
+        canvas['label']
+      end
+      hash
+    end
+
     def member_ids_for(presenter)
       member_ids = presenter.try(:ordered_ids) || presenter.try(:member_ids)
       member_ids.nil? ? [] : member_ids
@@ -128,4 +139,5 @@ module IiifPrint
       ActiveFedora::SolrService.query(query, fq: "-has_model_ssim:FileSet", rows: ids.size)
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -42,6 +42,11 @@ module IiifPrint
       manifest = manifest_factory.new(presenter).to_h
       hash = JSON.parse(manifest.to_json)
       hash = send("sanitize_v#{@version}", hash: hash, presenter: presenter)
+      if @child_works.present? && IiifPrint.config.sort_iiif_manifest_canvases_by
+        send("sort_canvases_v#{@version}",
+             hash: hash,
+             sort_field: IiifPrint.config.sort_iiif_manifest_canvases_by)
+      end
       hash
     end
 
@@ -76,6 +81,32 @@ module IiifPrint
       return unless image
       canvas_metadata = IiifPrint.manifest_metadata_from(work: image, presenter: presenter)
       canvas['metadata'] = canvas_metadata
+    end
+
+    LARGEST_SORT_ORDER_CHAR = '~'.freeze
+
+    def sort_canvases_v2(hash:, sort_field:)
+      sort_field = Hyrax::Renderers::AttributeRenderer.new(sort_field, nil).label
+      hash['sequences']&.first&.[]('canvases')&.sort_by! do |canvas|
+        selection = canvas['metadata'].select { |h| h['label'] == sort_field }
+        fallback = [{ label: sort_field,
+                      value: [LARGEST_SORT_ORDER_CHAR] }]
+        sort_field_metadata = selection.presence || fallback
+        sort_field_metadata.first['value'] if sort_field_metadata.present?
+      end
+      hash
+    end
+
+    def sort_canvases_v3(hash:, sort_field:)
+      sort_field = Hyrax::Renderers::AttributeRenderer.new(sort_field, nil).label
+      hash['items']&.sort_by! do |item|
+        selection = item['metadata'].select { |h| h['label'][I18n.locale.to_s] == [sort_field] }
+        fallback = [{ label: { "#{I18n.locale}": [sort_field] },
+                      value: { none: [LARGEST_SORT_ORDER_CHAR] } }]
+        sort_field_metadata = selection.presence || fallback
+        sort_field_metadata.first['value']['none'] if sort_field_metadata.present?
+      end
+      hash
     end
 
     def member_ids_for(presenter)

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -157,6 +157,14 @@ module IiifPrint
     end
 
     attr_writer :sort_iiif_manifest_canvases_by
+    ##
+    # Normally, the canvases are sorted by the `ordered_members` association.
+    # However, if you want it to be sorted by another property, you can set this
+    # configuration.  Change `nil` to something like `:title` or `:identifier`.
+    #
+    # Should you want to sort by the filename of the image, you
+    # set `nil` to `:label`.  This looks at the canvas label, which is typically set
+    # to the filename of the image.
     def sort_iiif_manifest_canvases_by
       @sort_iiif_manifest_canvases_by || nil
     end

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -155,5 +155,10 @@ module IiifPrint
         }
       end
     end
+
+    attr_writer :sort_iiif_manifest_canvases_by
+    def sort_iiif_manifest_canvases_by
+      @sort_iiif_manifest_canvases_by || nil
+    end
   end
 end

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -124,4 +124,15 @@ RSpec.describe IiifPrint::Configuration do
                                          [:keyreq, :admin_set_id]])
     end
   end
+
+  describe "#sort_iiif_manifest_canvases_by" do
+    subject { config.sort_iiif_manifest_canvases_by }
+
+    it { is_expected.to be_a NilClass }
+    it "allows for an override" do
+      original = config.sort_iiif_manifest_canvases_by
+      config.sort_iiif_manifest_canvases_by = :title
+      expect(config.metadata_fields).not_to eq original
+    end
+  end
 end


### PR DESCRIPTION
# Story

As a user, I want to see the UV display the different works in filename order.

Refs https://github.com/scientist-softserv/essi/issues/11

# Expected Behavior Before Changes

Canvas sort by ordered members no matter what

# Expected Behavior After Changes

Canvas sort by ordered members by default but can be configured to be sorted by work properties or canvas label.

[Add back canvas sorting with a configuration](https://github.com/scientist-softserv/iiif_print/commit/e4d197d11d0d38d1573d21f17deb10f7ad818077) 

# Commits

This commit will bring back a previously deprecated feature of sorting
the canvas.  This time, the canvas will only be sorted if the
configuration is set to do so.  The default is to not sort the canvas
and instead follow the order_members of the work.

---

[Add sort by canvas label](https://github.com/scientist-softserv/iiif_print/commit/febc3a033ecce8ffe969025889405eb4e457ac82) 

This commit will add a way to sort by the canvas label.  This is
useful for when the application needs the canvases to be sorted by the
filename of the image.

