### PR TITLE
Update GeneratedResourceSchema in childed_indexer

### DIFF
--- a/app/indexers/concerns/iiif_print/child_indexer.rb
+++ b/app/indexers/concerns/iiif_print/child_indexer.rb
@@ -19,7 +19,9 @@ module IiifPrint
           indexer.prepend(self)
           indexer.class_attribute(:iiif_print_lineage_service, default: IiifPrint::LineageService)
         end
-        work_type::GeneratedResourceSchema.send(:include, IiifPrint::SetChildFlag)
+        if work_type.const_defined?(:GeneratedResourceSchema)
+          work_type::GeneratedResourceSchema.send(:include, IiifPrint::SetChildFlag)
+        end
       end
     end
 

--- a/app/indexers/concerns/iiif_print/child_indexer.rb
+++ b/app/indexers/concerns/iiif_print/child_indexer.rb
@@ -19,9 +19,7 @@ module IiifPrint
           indexer.prepend(self)
           indexer.class_attribute(:iiif_print_lineage_service, default: IiifPrint::LineageService)
         end
-        if work_type.const_defined?(:GeneratedResourceSchema)
-          work_type::GeneratedResourceSchema.send(:include, IiifPrint::SetChildFlag)
-        end
+        work_type::GeneratedResourceSchema.send(:include, IiifPrint::SetChildFlag) if work_type.const_defined?(:GeneratedResourceSchema)
       end
     end
 


### PR DESCRIPTION
Set conditional to verify GeneratedResourceSchema is defined.

# Story

Refs 
https://github.com/orgs/scientist-softserv/projects/43?pane=issue&itemId=25971227

# Expected Behavior Before Changes 

After creating a new work type, a developer could not run the pending migrations due to work_type::GeneratedResourceSchema being undefined. 

# Expected Behavior After Changes

The condition statement added to the code verifies the constant "work_type::GeneratedResourceSchema" is defined. If defined, the code will execute. 