### PR TITLE
Updating allinson flex features

### DIFF
--- a/app/models/concerns/iiif_print/solr/document.rb
+++ b/app/models/concerns/iiif_print/solr/document.rb
@@ -53,4 +53,8 @@ module IiifPrint::Solr::Document
   def any_highlighting?
     response&.[]('highlighting')&.[](id)&.present?
   end
+
+  def solr_document
+    self
+  end
 end

--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -8,7 +8,9 @@ module IiifPrint
     attr_accessor :base_url
 
     def manifest_metadata
-      @manifest_metadata ||= IiifPrint.manifest_metadata_from(work: model, presenter: self)
+      # ensure we are using a SolrDocument
+      solr_doc = model.is_a?(SolrDocument) ? model : model.solr_document
+      @manifest_metadata ||= IiifPrint.manifest_metadata_from(work: solr_doc, presenter: self)
     end
 
     def search_service

--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -8,11 +8,8 @@ module IiifPrint
     attr_accessor :base_url
 
     def manifest_metadata
-      @manifest_metadata ||= begin
-                               # ensure we are using a SolrDocument
-                               solr_doc = model.is_a?(SolrDocument) ? model : model.solr_document
-                               IiifPrint.manifest_metadata_from(work: solr_doc, presenter: self)
-                             end
+      # ensure we are using a SolrDocument
+      @manifest_metadata ||= IiifPrint.manifest_metadata_from(work: model.solr_document, presenter: self)
     end
 
     def search_service

--- a/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_behavior.rb
@@ -8,9 +8,11 @@ module IiifPrint
     attr_accessor :base_url
 
     def manifest_metadata
-      # ensure we are using a SolrDocument
-      solr_doc = model.is_a?(SolrDocument) ? model : model.solr_document
-      @manifest_metadata ||= IiifPrint.manifest_metadata_from(work: solr_doc, presenter: self)
+      @manifest_metadata ||= begin
+                               # ensure we are using a SolrDocument
+                               solr_doc = model.is_a?(SolrDocument) ? model : model.solr_document
+                               IiifPrint.manifest_metadata_from(work: solr_doc, presenter: self)
+                             end
     end
 
     def search_service

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -154,11 +154,13 @@ module IiifPrint
     end
   end
 
-  def self.fields_for_allinson_flex(fields: allinson_flex_fields)
-    fields = sort_af_fields!(fields)
+  ##
+  # @param fields [Array<IiifPrint::Field>]
+  def self.fields_for_allinson_flex(fields: allinson_flex_fields, sort_order: IiifPrint.config.iiif_metadata_field_presentation_order)
+    fields = sort_af_fields!(fields, sort_order: sort_order)
     fields.each_with_object({}) do |field, hash|
       # filters out admin_only fields
-      next if field.indexing.include?('admin_only')
+      next if field.indexing&.include?('admin_only')
 
       # WARNING: This is assuming A LOT
       # This is taking the Allinson Flex fields that have the same name and only
@@ -172,13 +174,15 @@ module IiifPrint
       hash[field.name] = Field.new(
         name: field.name,
         label: field.value,
-        options: field.indexing.include?('facetable') ? { render_as: :faceted } : nil
+        options: field.indexing&.include?('facetable') ? { render_as: :faceted } : nil
       )
     end.values
   end
 
   CollectionFieldShim = Struct.new(:name, :value, :indexing, keyword_init: true)
 
+  ##
+  # @return [Array<IiifPrint::Field>]
   def self.allinson_flex_fields
     return @allinson_flex_fields if defined?(@allinson_flex_fields)
 
@@ -195,7 +199,10 @@ module IiifPrint
     @allinson_flex_fields = flex_fields
   end
 
-  def self.sort_af_fields!(fields, sort_order: IiifPrint.config.iiif_metadata_field_presentation_order)
+  ##
+  # @param fields [Array<IiifPrint::Field>]
+  # @param sort_order [Array<Symbol>]
+  def self.sort_af_fields!(fields, sort_order:)
     return fields if sort_order.blank?
 
     fields.sort_by do |field|

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -192,6 +192,8 @@ module IiifPrint
                              .distinct
                              .select(:name, :value, :indexing)
     flex_fields = allinson_flex_relation.to_a
+    # filters out admin_only fields
+    flex_fields.reject! { |profile| profile.indexing.include?('admin_only') }
     unless allinson_flex_relation.exists?(name: 'collection')
       collection_field = CollectionFieldShim.new(name: :collection, value: 'Collection', indexing: [])
       flex_fields << collection_field

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -195,6 +195,18 @@ module IiifPrint
         IiifPrint::Data::WorkDerivatives.data(from: object, of_type: 'txt')
       end
     end
+
+    attr_writer :iiif_metadata_sorter_fields
+    ##
+    # This is the default sorter for the metadata.  It will sort by the order of the keys specificied.
+    # By default, this is turned off as it returns nil. If you want to turn it on, you can set this
+    # this to an array of symbols the properties on the work.
+    #
+    # @example [:title, :description, :date_created]
+    # @return [Array<Symbol>]
+    def iiif_metadata_sorter_fields
+      @iiif_metadata_sorter_fields || nil
+    end
   end
   # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -207,6 +207,16 @@ module IiifPrint
     def iiif_metadata_sorter_fields
       @iiif_metadata_sorter_fields || nil
     end
+
+    def questioning_authority_fields=(fields)
+      @questioning_authority_fields = Array.wrap(fields).map(&:to_s)
+    end
+    ##
+    # This is used to explicitly set which fields should be rendered as a Questioning Authority in the UV.
+    # By default, we render `rights_statement` and `license` as QA fields.
+    def questioning_authority_fields
+      @questioning_authority_fields ||= ['rights_statement', 'license']
+    end
   end
   # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -196,7 +196,7 @@ module IiifPrint
       end
     end
 
-    attr_writer :iiif_metadata_sorter_fields
+    attr_writer :iiif_metadata_field_presentation_order
     ##
     # This is the default sorter for the metadata.  It will sort by the order of the keys specificied.
     # By default, this is turned off as it returns nil. If you want to turn it on, you can set this
@@ -204,13 +204,14 @@ module IiifPrint
     #
     # @example [:title, :description, :date_created]
     # @return [Array<Symbol>]
-    def iiif_metadata_sorter_fields
-      @iiif_metadata_sorter_fields || nil
+    def iiif_metadata_field_presentation_order
+      @iiif_metadata_field_presentation_order || nil
     end
 
     def questioning_authority_fields=(fields)
       @questioning_authority_fields = Array.wrap(fields).map(&:to_s)
     end
+
     ##
     # This is used to explicitly set which fields should be rendered as a Questioning Authority in the UV.
     # By default, we render `rights_statement` and `license` as QA fields.

--- a/lib/iiif_print/metadata.rb
+++ b/lib/iiif_print/metadata.rb
@@ -67,7 +67,7 @@ module IiifPrint
     def cast_to_value(field_name:, options:)
       if options&.[](:render_as) == :faceted
         faceted_values_for(field_name: field_name)
-      elsif options&.[](:render_as) == :rights_statement || options&.[](:render_as) == :license
+      elsif qa_field?(field_name: options&.dig(:render_as)) || qa_field?(field_name: field_name)
         authority_values_for(field_name: field_name)
       else
         make_link(values_for(field_name: field_name))
@@ -83,6 +83,12 @@ module IiifPrint
         path += '&include_child_works=true' if work["is_child_bsi"] == true
         "<a href='#{File.join(@base_url, path)}'>#{value}</a>"
       end
+    end
+
+    def qa_field?(field_name:)
+      # assuming that rights_statement and license are fields that use questioning authority
+      # this will allow Allinson Flex applications that don't have render_as options to still use QA
+      ['rights_statement', 'license'].include?(field_name.to_s)
     end
 
     def authority_values_for(field_name:)

--- a/lib/iiif_print/metadata.rb
+++ b/lib/iiif_print/metadata.rb
@@ -67,7 +67,7 @@ module IiifPrint
     def cast_to_value(field_name:, options:)
       if options&.[](:render_as) == :faceted
         faceted_values_for(field_name: field_name)
-      elsif qa_field?(field_name: options&.dig(:render_as)) || qa_field?(field_name: field_name)
+      elsif qa_field?(field_name: options&.dig(:render_as) || field_name)
         authority_values_for(field_name: field_name)
       else
         make_link(values_for(field_name: field_name))
@@ -85,10 +85,8 @@ module IiifPrint
       end
     end
 
-    def qa_field?(field_name:)
-      # assuming that rights_statement and license are fields that use questioning authority
-      # this will allow Allinson Flex applications that don't have render_as options to still use QA
-      ['rights_statement', 'license'].include?(field_name.to_s)
+    def qa_field?(field_name:, questioning_authority_fields: IiifPrint.config.questioning_authority_fields)
+      questioning_authority_fields.include?(field_name.to_s)
     end
 
     def authority_values_for(field_name:)

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -162,4 +162,19 @@ RSpec.describe IiifPrint::Configuration do
       expect(config.iiif_metadata_sorter_fields).not_to eq original
     end
   end
+
+  describe "#questioning_authority_fields" do
+    subject { config.questioning_authority_fields }
+
+    it { is_expected.to be_a Array }
+    context "by default" do
+      it { is_expected.to eq ['rights_statement', 'license'] }
+    end
+
+    it "allows for an override" do
+      expect do
+        config.questioning_authority_fields = ['rights_statement', 'license', 'subject']
+      end.to change(config, :questioning_authority_fields).from(['rights_statement', 'license']).to(['rights_statement', 'license', 'subject'])
+    end
+  end
 end

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -152,14 +152,14 @@ RSpec.describe IiifPrint::Configuration do
     end
   end
 
-  describe "#iiif_metadata_sorter_fields" do
-    subject { config.iiif_metadata_sorter_fields }
+  describe "#iiif_metadata_field_presentation_order" do
+    subject { config.iiif_metadata_field_presentation_order }
 
     it { is_expected.to be_a NilClass }
     it "allows for an override" do
-      original = config.iiif_metadata_sorter_fields
-      config.iiif_metadata_sorter_fields = :title
-      expect(config.iiif_metadata_sorter_fields).not_to eq original
+      original = config.iiif_metadata_field_presentation_order
+      config.iiif_metadata_field_presentation_order = :title
+      expect(config.iiif_metadata_field_presentation_order).not_to eq original
     end
   end
 

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -151,4 +151,15 @@ RSpec.describe IiifPrint::Configuration do
       expect(function.parameters).to eq([[:keyreq, :object]])
     end
   end
+
+  describe "#iiif_metadata_sorter_fields" do
+    subject { config.iiif_metadata_sorter_fields }
+
+    it { is_expected.to be_a NilClass }
+    it "allows for an override" do
+      original = config.iiif_metadata_sorter_fields
+      config.iiif_metadata_sorter_fields = :title
+      expect(config.iiif_metadata_sorter_fields).not_to eq original
+    end
+  end
 end

--- a/spec/iiif_print_spec.rb
+++ b/spec/iiif_print_spec.rb
@@ -45,4 +45,72 @@ RSpec.describe IiifPrint do
       end
     end
   end
+
+  describe ".fields_for_allinson_flex" do
+    subject { described_class.fields_for_allinson_flex(fields: fields, sort_order: sort_order) }
+    let(:sort_order) { [] }
+
+    context "when the fields include an admin only indexing property" do
+      let(:fields) do
+        [
+          IiifPrint::CollectionFieldShim.new(name: :title, value: "My Title"),
+          IiifPrint::CollectionFieldShim.new(name: :creator, value: "Hyrax, Sam", indexing: ["admin_only"])
+        ]
+      end
+
+      it "does not include the admin only field" do
+        # We are mapping from one data structure to another
+        expect(subject.map(&:name)).to eq([fields.first.name])
+      end
+    end
+
+    context "when the fields include duplicate name properties" do
+      let(:fields) do
+        [
+          IiifPrint::CollectionFieldShim.new(name: :title, value: "My Title"),
+          IiifPrint::CollectionFieldShim.new(name: :title, value: "My Other Title")
+        ]
+      end
+
+      it "does not include later duplicates" do
+        expect(subject.map(&:label)).to eq([fields.first.value])
+      end
+    end
+
+    context "when we provide a fields sort order" do
+      let(:fields) do
+        [
+          IiifPrint::CollectionFieldShim.new(name: :title, value: "My Title"),
+          IiifPrint::CollectionFieldShim.new(name: :creator, value: "Hyrax, Sam"),
+          IiifPrint::CollectionFieldShim.new(name: :date_created, value: "2023-05-02")
+        ]
+      end
+      let(:sort_order) { [:creator, :title] }
+
+      it "returns the fields in the order specified and puts unspecified fields last" do
+        expect(subject.map(&:name)).to eq([:creator, :title, :date_created])
+      end
+    end
+  end
+
+  describe ".sort_af_fields!" do
+    let(:fields) { [:title, :creator, :date_created].map { |name| IiifPrint::Field.new(name: name) } }
+    subject(:sort_af_fields) { described_class.sort_af_fields!(fields, sort_order: sort_order) }
+
+    context "when the sort order is an empty array" do
+      let(:sort_order) { [] }
+
+      it "returns the fields in the order they were given" do
+        expect(sort_af_fields).to eq(fields)
+      end
+    end
+
+    context "when the sort order specifies some of the fields" do
+      let(:sort_order) { [:date_created, :title] }
+
+      it "returns the fields in the order specified and puts unspecified fields last" do
+        expect(sort_af_fields).to eq([:date_created, :title, :creator].map { |name| IiifPrint::Field.new(name: name) })
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Filter out admin_only fields](https://github.com/scientist-softserv/iiif_print/commit/6b854e3379cfb960882efca1a0f2445e00de2779) 

This commit will filter out metadata fields that are meant to be admin
only from displaying in the UV.  This is done by adding a reject if the
Allinson Flex profile indicates that this field is `admin_only`.

---

[Make QA work for allinson_flex](https://github.com/scientist-softserv/iiif_print/commit/ce4074ed060c717e687ff757176343d955d82a38) 

Allinson Flex profiles don't have an option other than indicating which
fields to be facetable.  This commit will make QA work for Allinson Flex
by assuming the field names "rights_statement" and "license" will be QA
fields.

---

[Add a way to sort Allinson Flex metadata](https://github.com/scientist-softserv/iiif_print/commit/50b1f78cacd7d1ba90344adde18f0f6bf29ecb99) 

This configuration allows you to sort the metadata within an application
that uses Allinson Flex.  In a non-Allinson Flex application, you would
use the `IiifPrint.config.metadata_fields` to sort the metadata.  However,
in Allinson Flex, the fields come in according to the m3 profile.  This
configuration allows you to use an Array of Symbols to sort the metadata
in an intentional way.

Some profiles have fields with the same name repeated.  This commit will
remove repeated fields though this functionality just takes the first
field and ignores the rest.  This isn't very controlled at the moment
but works for Essi's situation.

Ex. Imagine if you had fields of:
```rb
[
  #<AllinsonFlex::ProfileProperty id: nil, name: "title", indexing: ["stored_searchable"]>,
  #<AllinsonFlex::ProfileProperty id: nil, name: "title", indexing: ["stored_searchable"]>
 ]
```

The first object would yield
**Title: My Sweet Title**

and the second field would yield
**Photograph Information: My Sweet Title**

The second field would be ignored since the value is the same as the
first field.  This is how Essi displays their metadata so we will use
this method until told otherwise.

---

[Ensure we're using a SolrDcoument](https://github.com/scientist-softserv/iiif_print/pull/231/commits/9c7f1fdd444e5abc8000e2d68b30f7bfaa8572a4) 

For Essi to use the #manifest_metadata method, we need to ensure that
the `model` is a SolrDocument.  We will now make a check to see if the
`model` is a SolrDocument, and if not, we will attempt to convert it to
one.