### PR TITLE
Fixed tesseract spelling errors

### DIFF
--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -117,14 +117,14 @@ module IiifPrint
     end
     # rubocop:enable Metrics/MethodLength
 
-    attr_writer :additional_tessearct_options
+    attr_writer :additional_tesseract_options
     ##
     # The additional options to pass to the Tesseract configuration
     #
     # @see https://tesseract-ocr.github.io/tessdoc/Command-Line-Usage.html
     # @return [String]
-    def additional_tessearct_options
-      @additional_tessearct_options || ""
+    def additional_tesseract_options
+      @additional_tesseract_options || ""
     end
 
     attr_writer :uv_config_path

--- a/lib/iiif_print/text_extraction/page_ocr.rb
+++ b/lib/iiif_print/text_extraction/page_ocr.rb
@@ -9,7 +9,7 @@ module IiifPrint
     class PageOCR
       attr_accessor :html, :path
 
-      def initialize(path, additional_tessearct_options: IiifPrint.config.additional_tessearct_options)
+      def initialize(path, additional_tesseract_options: IiifPrint.config.additional_tesseract_options)
         @path = path
         # hOCR html:
         @html = nil
@@ -17,13 +17,13 @@ module IiifPrint
         @source_meta = nil
         @box = nil
         @plain = nil
-        @additional_tessearct_options = additional_tessearct_options
+        @additional_tesseract_options = additional_tesseract_options
       end
 
       def run_ocr
         outfile = File.join(Dir.mktmpdir, 'output_html')
         cmd = "OMP_THREAD_LIMIT=1 tesseract #{path} #{outfile}"
-        cmd += " #{@additional_tessearct_options}" if @additional_tessearct_options.present?
+        cmd += " #{@additional_tesseract_options}" if @additional_tesseract_options.present?
         cmd += " hocr"
         `#{cmd}`
         outfile + '.hocr'

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -81,16 +81,16 @@ RSpec.describe IiifPrint::Configuration do
     end
   end
 
-  describe '#additional_tessearct_options' do
+  describe '#additional_tesseract_options' do
     context "by default" do
-      subject { config.additional_tessearct_options }
+      subject { config.additional_tesseract_options }
       it { is_expected.not_to be_present }
     end
 
     it "can be configured" do
       expect do
-        config.additional_tessearct_options = "-l esperanto"
-      end.to change(config, :additional_tessearct_options)
+        config.additional_tesseract_options = "-l esperanto"
+      end.to change(config, :additional_tesseract_options)
         .from("")
         .to("-l esperanto")
     end


### PR DESCRIPTION
This commit contains the fixes for the tesseract typos throughout the
repository.

# Story
While testing iiif_print in Adventist, the team noticed the misspelling of tesseract.
