### PR TITLE
Search parent metadata instead of no match found

### DIFF
--- a/app/models/iiif_print/iiif_search_decorator.rb
+++ b/app/models/iiif_print/iiif_search_decorator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# OVERRIDE: Blacklight IIIF Search v1.0.0
+# IiifSearchDecorator module extends the functionality of the BlacklightIiifSearch::IiifSearch class
+# by overriding the solr_params method to modify the search query to include the parent's metadata.
+module IiifPrint
+  module IiifSearchDecorator
+    ##
+    # Overrides the solr_params method from BlacklightIiifSearch::IiifSearch to modify the search query.
+    # The method adds an additional filter to the query to include either the object_relation_field OR the
+    # parent document's id and removes the :f parameter from the query.
+    # :object_relation_field refers to the CatalogController's configuration which is typically set to
+    # 'is_page_of_ssim' in the host application which only searches child works by default.
+    #
+    #   config.iiif_search = {
+    #     full_text_field: 'all_text_tsimv',
+    #     object_relation_field: 'is_page_of_ssim',
+    #     supported_params: %w[q page],
+    #     autocomplete_handler: 'iiif_suggest',
+    #     suggester_name: 'iiifSuggester'
+    #   }
+    #
+    # @return [Hash] A hash containing the modified Solr search parameters
+    #
+    def solr_params
+      return { q: 'nil:nil' } unless q
+
+      {
+        q: "#{q} AND (#{iiif_config[:object_relation_field]}:\"#{parent_document.id}\" OR id:\"#{parent_document.id}\")",
+        rows: rows,
+        page: page
+      }
+    end
+  end
+end

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -48,6 +48,7 @@ module IiifPrint
 
       ::BlacklightIiifSearch::IiifSearchResponse.prepend(IiifPrint::IiifSearchResponseDecorator)
       ::BlacklightIiifSearch::IiifSearchAnnotation.prepend(IiifPrint::BlacklightIiifSearch::AnnotationDecorator)
+      ::BlacklightIiifSearch::IiifSearch.prepend(IiifPrint::IiifSearchDecorator)
       Hyrax::Actors::FileSetActor.prepend(IiifPrint::Actors::FileSetActorDecorator)
 
       Hyrax.config do |config|

--- a/spec/models/iiif_print/iiif_search_decorator_spec.rb
+++ b/spec/models/iiif_print/iiif_search_decorator_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe IiifPrint::IiifSearchDecorator do
+  let(:iiif_config) { { object_relation_field: 'is_page_of_ssim' } }
+  let(:parent_document) { double(SolrDocument, id: 'abc123') }
+  let(:iiif_search) { BlacklightIiifSearch::IiifSearch.new(params, iiif_config, parent_document) }
+
+  describe '#solr_params' do
+    subject { iiif_search.solr_params }
+
+    context 'when q is nil' do
+      let(:params) { { q: nil } }
+
+      it 'returns nil:nil' do
+        expect(subject).to eq({ q: 'nil:nil' })
+      end
+    end
+
+    context 'when q is not nil' do
+      let(:params) { { q: 'catscan' } }
+
+      it 'returns a query with the search term and filters for child or parent id' do
+        expect(subject).to eq({ q: "catscan AND (is_page_of_ssim:\"abc123\" OR id:\"abc123\")", rows: 50, page: nil })
+      end
+    end
+  end
+end


### PR DESCRIPTION
ref: https://github.com/scientist-softserv/essi/issues/23, https://github.com/scientist-softserv/essi/issues/24

This commit will override `BlacklightIiifSearch::IiifSearch#solr_params` to include the parent metadata fields in a UV search.

<img width="1391" alt="image" src="https://user-images.githubusercontent.com/19597776/236349330-73a5d6ee-6205-44ba-a675-6ae482e5fe3c.png">
