### PR TITLE
Don't show child metadata on the parent image

### DIFF
--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -43,7 +43,7 @@ module IiifPrint
       manifest = manifest_factory.new(presenter).to_h
       hash = JSON.parse(manifest.to_json)
       parent_and_child_solr_hits = parent_and_child_solr_hits(presenter) if @child_works.present?
-      hash = send("sanitize_v#{@version}", hash: hash, presenter: presenter, hits: parent_and_child_solr_hits)
+      hash = send("sanitize_v#{@version}", hash: hash, presenter: presenter, solr_doc_hits: parent_and_child_solr_hits)
       if @child_works.present? && IiifPrint.config.sort_iiif_manifest_canvases_by
         send("sort_canvases_v#{@version}",
              hash: hash,
@@ -52,34 +52,34 @@ module IiifPrint
       hash
     end
 
-    def sanitize_v2(hash:, presenter:, hits:)
+    def sanitize_v2(hash:, presenter:, solr_doc_hits:)
       hash['label'] = CGI.unescapeHTML(sanitize_value(hash['label'])) if hash.key?('label')
       hash.delete('description') # removes default description since it's in the metadata fields
       hash['sequences']&.each do |sequence|
         sequence['canvases']&.each do |canvas|
           canvas['label'] = CGI.unescapeHTML(sanitize_value(canvas['label']))
-          apply_metadata_to_canvas(canvas: canvas, presenter: presenter, hits: hits)
+          apply_metadata_to_canvas(canvas: canvas, presenter: presenter, solr_doc_hits: solr_doc_hits)
         end
       end
       hash
     end
 
-    def sanitize_v3(hash:, presenter:, hits:)
+    def sanitize_v3(hash:, presenter:, solr_doc_hits:)
       hash['label']['none'].map! { |text| CGI.unescapeHTML(sanitize_value(text)) } if hash.key('label')
       hash['items'].each do |canvas|
         canvas['label']['none'].map! { |text| CGI.unescapeHTML(sanitize_value(text)) }
-        apply_metadata_to_canvas(canvas: canvas, presenter: presenter, hits: hits)
+        apply_metadata_to_canvas(canvas: canvas, presenter: presenter, solr_doc_hits: solr_doc_hits)
       end
       hash
     end
 
-    def apply_metadata_to_canvas(canvas:, presenter:, hits:)
+    def apply_metadata_to_canvas(canvas:, presenter:, solr_doc_hits:)
       return if @child_works.empty?
 
       # uses the 'id' property for v3 manifest and `@id' for v2, which is a URL that contains the FileSet id
       file_set_id = (canvas['id'] || canvas['@id']).split('/').last
       # finds the image that the FileSet is attached to and creates metadata on that canvas
-      image = hits.find { |hit| hit[:member_ids_ssim]&.include?(file_set_id) }
+      image = solr_doc_hits.find { |hit| hit[:member_ids_ssim]&.include?(file_set_id) }
       return unless image
       # prevents duplicating the child and parent metadata
       return if image.id == presenter.id

--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -75,13 +75,16 @@ module IiifPrint
 
     def apply_metadata_to_canvas(canvas:, presenter:, hits:)
       return if @child_works.empty?
+
       # uses the 'id' property for v3 manifest and `@id' for v2, which is a URL that contains the FileSet id
       file_set_id = (canvas['id'] || canvas['@id']).split('/').last
       # finds the image that the FileSet is attached to and creates metadata on that canvas
-      image = hits.find { |doc| doc[:member_ids_ssim]&.include?(file_set_id) }
+      image = hits.find { |hit| hit[:member_ids_ssim]&.include?(file_set_id) }
       return unless image
-      canvas_metadata = IiifPrint.manifest_metadata_from(work: image, presenter: presenter)
-      canvas['metadata'] = canvas_metadata
+      # prevents duplicating the child and parent metadata
+      return if image.id == presenter.id
+
+      canvas['metadata'] = IiifPrint.manifest_metadata_from(work: image, presenter: presenter)
     end
 
     LARGEST_SORT_ORDER_CHAR = '~'.freeze

--- a/iiif_print.gemspec
+++ b/iiif_print.gemspec
@@ -25,7 +25,7 @@ SUMMARY
   spec.add_dependency 'blacklight_iiif_search', '~> 1.0'
   spec.add_dependency 'dry-monads', '~> 1.4.0'
   spec.add_dependency 'hyrax', '>= 2.5', '< 4.0'
-  spec.add_dependency 'valkyrie', '~> 3.0'
+  spec.add_dependency 'reform-rails', '0.2.3'
   spec.add_dependency 'nokogiri', '>=1.13.2'
   spec.add_dependency 'rails', '~> 5.0'
   spec.add_dependency 'rdf-vocab', '~> 3.0'

--- a/iiif_print.gemspec
+++ b/iiif_print.gemspec
@@ -25,6 +25,7 @@ SUMMARY
   spec.add_dependency 'blacklight_iiif_search', '~> 1.0'
   spec.add_dependency 'dry-monads', '~> 1.4.0'
   spec.add_dependency 'hyrax', '>= 2.5', '< 4.0'
+  spec.add_dependency 'valkyrie', '~> 3.0'
   spec.add_dependency 'nokogiri', '>=1.13.2'
   spec.add_dependency 'rails', '~> 5.0'
   spec.add_dependency 'rdf-vocab', '~> 3.0'


### PR DESCRIPTION
Prior to this commit, the metadata for the parent image would display both on the manifest and canvas levels. In this commit, we check if the image we are looking at is on the parent or the child.  If it is on the parent, we won't display it on the canvas level because it is already being displayed on the manifest level.

Before:
![image](https://user-images.githubusercontent.com/19597776/236868172-269c521d-b2ce-4c9d-840f-36572ddf4fe7.png)

After:
![image](https://user-images.githubusercontent.com/19597776/236867942-3007732c-6ce8-4293-8cb5-cce748b39c31.png)
