### PR TITLE
[i387] - add default value to is_child property

### DIFF
--- a/app/indexers/concerns/iiif_print/child_indexer.rb
+++ b/app/indexers/concerns/iiif_print/child_indexer.rb
@@ -25,7 +25,7 @@ module IiifPrint
 
     def generate_solr_document
       super.tap do |solr_doc|
-        solr_doc['is_child_bsi'] = object.is_child
+        solr_doc['is_child_bsi'] ||= object.is_child
         solr_doc['is_page_of_ssim'] = iiif_print_lineage_service.ancestor_ids_for(object)
 
         # Due to a long-standing hack in Hyrax, the file_set_ids_ssim contains both file_set_ids and

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -152,7 +152,8 @@ module IiifPrint
           admin_set_id: admin_set_id.to_s,
           creator: parent_work.creator.to_a,
           rights_statement: parent_work.rights_statement.to_a,
-          visibility: parent_work.visibility.to_s
+          visibility: parent_work.visibility.to_s,
+          is_child: true
         }
       end
     end


### PR DESCRIPTION
# Story

This PR is to address the feedback from the following ticket. The user was still able to see the child works in the catalog and recent works section. To resolve this, we are setting the child work is_child attribute to be true on default. 

Refs https://github.com/scientist-softserv/britishlibrary/issues/387

# Expected Behavior Before Changes
ref: https://github.com/scientist-softserv/britishlibrary/issues/387#issuecomment-1542771258

![image](https://github.com/scientist-softserv/iiif_print/assets/10081604/d64e4c13-5480-4ab7-8ad9-114b74e76094)


# Expected Behavior After Changes

As a result, you cannot see the child records while it's still processing. The user should and does not see child works in the following scenarios: 

## EMPTY CATALOG SEARCH :
![image](https://github.com/scientist-softserv/iiif_print/assets/10081604/214197ba-8888-411c-aa65-235baf78619e)

## RECENT WORKS SECTION: 
![image](https://github.com/scientist-softserv/iiif_print/assets/10081604/84348636-b2d4-48b0-a37d-305570baada4)

## VIEW RECENT ADDITIONS CATALOG PG: 
![image](https://github.com/scientist-softserv/iiif_print/assets/10081604/12017ebd-0e1d-4a98-b84f-a0345cbaee44)


## Sidekiq
Notice is_child property is being set to true in the CreateWorkJob: 

![image](https://github.com/scientist-softserv/iiif_print/assets/10081604/a7638aa9-dd30-4b3f-ac9c-d247b78e9bbc)

sample work: [service-rbc-rbc0001-2015-2015gen56010-2015gen56010.pdf](https://github.com/scientist-softserv/iiif_print/files/11456897/service-rbc-rbc0001-2015-2015gen56010-2015gen56010.pdf)

# Notes