### PR TITLE
🐛 Fix a `NilClass` error

### DIFF
--- a/app/services/iiif_print/pluggable_derivative_service.rb
+++ b/app/services/iiif_print/pluggable_derivative_service.rb
@@ -109,7 +109,7 @@ class IiifPrint::PluggableDerivativeService
     return Array(default_plugins) if parent.nil?
     return Array(default_plugins) unless parent.respond_to?(:iiif_print_config)
 
-    (file_set.parent.iiif_print_config.derivative_service_plugins + Array(default_plugins)).flatten.compact.uniq
+    (parent.iiif_print_config.derivative_service_plugins + Array(default_plugins)).flatten.compact.uniq
   end
 
   def parent_for(file_set)


### PR DESCRIPTION
[🐛 Fix a NilClass error](https://github.com/scientist-softserv/iiif_print/commit/445f6cc7ec1e7376860a33f0a95f2c4abee57ae9) 

This will fix a bug in Adventist when a work couldn't be deleted.

<img width="908" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/280ae508-f6ca-4957-a15b-1c2e69e9965a">
