### PR TITLE
🐛 Fix additional query terms removal

### DIFF
--- a/spec/iiif_print/blacklight_iiif_search/annotation_decorator_spec.rb
+++ b/spec/iiif_print/blacklight_iiif_search/annotation_decorator_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe IiifPrint::BlacklightIiifSearch::AnnotationDecorator do
     SolrDocument.new('id' => parent_id,
                      'has_model_ssim' => ['NewspaperIssue'])
   end
+  let(:query) { "software AND (is_page_of_ssim:#{parent_id} OR id:#{parent_id})" }
   let(:iiif_search_annotation) do
-    BlacklightIiifSearch::IiifSearchAnnotation.new(page_document, 'software',
+    BlacklightIiifSearch::IiifSearchAnnotation.new(page_document, query,
                                                    0, nil, controller,
                                                    parent_document)
   end


### PR DESCRIPTION
This commit will fix the removal of the additional query terms.  Here we use a regular expression to remove the additional query terms from the query string instead of using the `gsub` method.  This is more accurate because it was noticed that `document['is_page_of_ssim']` isn't always what we expect.  It does not work in a nested work context.
