### PR TITLE
⚙️ Remove `reform-rails` dependency

### DIFF
--- a/iiif_print.gemspec
+++ b/iiif_print.gemspec
@@ -26,7 +26,6 @@ SUMMARY
   spec.add_dependency 'derivative-rodeo'
   spec.add_dependency 'dry-monads', '~> 1.4.0'
   spec.add_dependency 'hyrax', '>= 2.5', '< 4'
-  spec.add_dependency 'reform-rails', '0.2.3'
   spec.add_dependency 'nokogiri', '>=1.13.2'
   spec.add_dependency 'rails', '~> 5.0'
   spec.add_dependency 'rdf-vocab', '~> 3.0'


### PR DESCRIPTION
This commit removes `reform-rails v0.2.3` as a hard dependency because v0.2.5 fixed the problem that caused Hyrax not to build.

- See https://github.com/trailblazer/reform-rails/issues/99
