### PR TITLE
♻️ Preparing Splitter Service Swap for DerivativeRodeo

### DIFF
--- a/app/services/iiif_print/pluggable_derivative_service.rb
+++ b/app/services/iiif_print/pluggable_derivative_service.rb
@@ -105,16 +105,10 @@ class IiifPrint::PluggableDerivativeService
   # set would use.  That "possibility" is based on the work.  Later, we will check the plugin's
   # "valid?" which would now look at the specific file_set for validity.
   def plugins_for(file_set)
-    parent = parent_for(file_set)
+    parent = IiifPrint.parent_for(file_set)
     return Array(default_plugins) if parent.nil?
     return Array(default_plugins) unless parent.respond_to?(:iiif_print_config)
 
     (parent.iiif_print_config.derivative_service_plugins + Array(default_plugins)).flatten.compact.uniq
-  end
-
-  def parent_for(file_set)
-    # fallback to Fedora-stored relationships if work's aggregation of
-    #   file set is not indexed in Solr
-    file_set.parent || file_set.member_of.find(&:work?)
   end
 end

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -39,6 +39,15 @@ module IiifPrint
     @config
   end
 
+  ##
+  # @param file_set [FileSet]
+  # @return [#work?, Hydra::PCDM::Work]
+  def self.parent_for(file_set)
+    # fallback to Fedora-stored relationships if work's aggregation of
+    #   file set is not indexed in Solr
+    file_set.parent || file_set.member_of.find(&:work?)
+  end
+
   DEFAULT_MODEL_CONFIGURATION = {
     # Split a PDF into individual page images and create a new child work for each image.
     pdf_splitter_job: IiifPrint::Jobs::ChildWorksFromPdfJob,

--- a/lib/iiif_print/split_pdfs/base_splitter.rb
+++ b/lib/iiif_print/split_pdfs/base_splitter.rb
@@ -9,8 +9,22 @@ module IiifPrint
     #
     # The purpose of this class is to split the PDF into constituent image files.
     #
-    # @see #each
+    # @see .call
     class BaseSplitter
+      ##
+      # @api public
+      #
+      # @param path [String] local path to the PDF that we will split.
+      # @return [Enumerable]
+      #
+      # @see #each
+      #
+      # @note We're including the ** args to provide method conformity; other services require
+      #       additional information (such as the FileSet)
+      def self.call(path, **)
+        new(path).to_a
+      end
+
       class_attribute :image_extension
       class_attribute :compression, default: nil
       class_attribute :quality, default: nil

--- a/lib/iiif_print/split_pdfs/child_work_creation_from_pdf_service.rb
+++ b/lib/iiif_print/split_pdfs/child_work_creation_from_pdf_service.rb
@@ -23,7 +23,7 @@ module IiifPrint
       # @return [TrueClass] when we actually enqueue the job underlying job.
       # rubocop:disable Metrics/MethodLength
       def self.conditionally_enqueue(file_set:, file:, user:, import_url: nil, work: nil)
-        work ||= parent_for(file_set: file_set)
+        work ||= IiifPrint.parent_for(file_set)
 
         return :no_split_for_parent unless iiif_print_split?(work: work)
         return :no_pdfs_for_import_url if import_url && !pdfs?(paths: [import_url])
@@ -35,7 +35,7 @@ module IiifPrint
         return :no_pdfs if file_locations.empty?
 
         work.iiif_print_config.pdf_splitter_job.perform_later(
-          work,
+          file_set,
           file_locations,
           user,
           admin_set_id,
@@ -114,11 +114,6 @@ module IiifPrint
 
       ##
       # @api private
-      def self.parent_for(file_set:)
-        # fallback to Fedora-stored relationships if work's aggregation of
-        #   file set is not indexed in Solr
-        file_set.parent || file_set.member_of.find(&:work?)
-      end
     end
   end
 end

--- a/spec/iiif_print/split_pdfs/base_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/base_splitter_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 RSpec.describe IiifPrint::SplitPdfs::BaseSplitter do
   let(:path) { __FILE__ }
   let(:splitter) { described_class.new(path) }
+  subject { described_class }
+
+  it { is_expected.to respond_to(:call) }
 
   describe "instance" do
     subject { splitter }


### PR DESCRIPTION
This commit is a refactor in-place.  The primary goal is to allow for passing the file_set to the child works; something that is ideal for the derivative rodeo's interface.

This is intended to be a swap-in-place change.  That is to say, if we deploy this change and have already enqueued jobs, nothing will fail nor break.  The past enqueued jobs (with a work) will use the work based logic but future enqueueings will use file_set.

In using the file_set, we also avoid the issue of having passing a `nil` as the parent, and thus creating an infinite rescheduling cycle.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/220

# Story

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes