### PR TITLE
🎁 Add derivative_rodeo_splitter

### DIFF
--- a/app/services/iiif_print/derivative_rodeo_service.rb
+++ b/app/services/iiif_print/derivative_rodeo_service.rb
@@ -168,7 +168,7 @@ module IiifPrint
           input_uris: [input_uri],
           pre_processed_location_template: pre_processed_location_template,
           output_location_template: output_location_template
-        ).generate_uris
+        ).generated_files
       end
     end
 

--- a/app/services/iiif_print/derivative_rodeo_service.rb
+++ b/app/services/iiif_print/derivative_rodeo_service.rb
@@ -66,6 +66,7 @@ module IiifPrint
     # @param extension [String]
     #
     # @return [String]
+    # rubocop:disable Metrics/MethodLength
     def self.derivative_rodeo_uri(file_set:, filename: nil, extension: nil)
       parent = IiifPrint.parent_for(file_set)
       raise IiifPrint::DataError, "Parent not found for #{file_set.class} ID=#{file_set.id}" unless parent
@@ -110,6 +111,7 @@ module IiifPrint
         File.join(location.adapter_prefix, dirname, "#{basename}#{extension}")
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     def initialize(file_set)
       @file_set = file_set

--- a/app/services/iiif_print/derivative_rodeo_service.rb
+++ b/app/services/iiif_print/derivative_rodeo_service.rb
@@ -25,9 +25,9 @@ module IiifPrint
     class_attribute :parent_work_identifier_property_name, default: 'aark_id'
 
     ##
-    # @attr pre_processed_location_adapter_name [String] The name of a derivative rodeo storage location;
+    # @attr preprocessed_location_adapter_name [String] The name of a derivative rodeo storage location;
     #       this will must be a registered with the DerivativeRodeo::StorageLocations::BaseLocation.
-    class_attribute :pre_processed_location_adapter_name, default: 's3'
+    class_attribute :preprocessed_location_adapter_name, default: 's3'
 
     ##
     # @attr named_derivatives_and_generators_by_type [Hash<Symbol, #constantize>] the named

--- a/app/services/iiif_print/pluggable_derivative_service.rb
+++ b/app/services/iiif_print/pluggable_derivative_service.rb
@@ -39,7 +39,7 @@ class IiifPrint::PluggableDerivativeService
   #   multiple plugins, some of which may or may not be valid, so
   #   validity checks happen within as well.
   def valid?
-    !valid_plugins.size.zero?
+    !valid_plugins.empty?
   end
 
   # get derivative services relevant to method name and file_set context

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,12 +85,12 @@ services:
     environment:
       - VIRTUAL_PORT=3000
       - VIRTUAL_HOST=.hyku.test
-    command: tail -f /dev/null
+    # command: tail -f /dev/null
     ##
     ## Similar to the above, except we will bundle and then tell the container
     ## to wait.  You'll then need to bash into the web container to do much of
     ## anything.
-    # command: sh -l -c "bundle && echo \"Finished bundling now waiting...\" && tail -f /dev/null"
+    command: sh -l -c "bundle install && echo \"Finished bundling now waiting...\" && tail -f /dev/null"
     depends_on:
       db:
         condition: service_started

--- a/iiif_print.gemspec
+++ b/iiif_print.gemspec
@@ -23,7 +23,7 @@ SUMMARY
   spec.files = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.add_dependency 'blacklight_iiif_search', '~> 1.0'
-  spec.add_dependency 'derivative-rodeo'
+  spec.add_dependency 'derivative-rodeo', "~> 0.3"
   spec.add_dependency 'dry-monads', '~> 1.4.0'
   spec.add_dependency 'hyrax', '>= 2.5', '< 4'
   spec.add_dependency 'nokogiri', '>=1.13.2'

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -19,6 +19,7 @@ require "iiif_print/blacklight_iiif_search/annotation_decorator"
 require "iiif_print/jobs/child_works_from_pdf_job"
 require "iiif_print/split_pdfs/base_splitter"
 require "iiif_print/split_pdfs/child_work_creation_from_pdf_service"
+require "iiif_print/split_pdfs/derivative_rodeo_splitter"
 
 module IiifPrint
   extend ActiveSupport::Autoload

--- a/lib/iiif_print/data/fileset_helper.rb
+++ b/lib/iiif_print/data/fileset_helper.rb
@@ -7,7 +7,7 @@ module IiifPrint
         # if context is itself a string, presume it is a file set id
         return @work if @work.is_a? String
         # if context is not a String, presume a work or fileset context:
-        fileset.nil? ? nil : fileset.id
+        fileset&.id
       end
 
       def first_fileset

--- a/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
+++ b/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
@@ -22,13 +22,13 @@ module IiifPrint
       def initialize(path, file_set:, output_tmp_dir: Dir.tmpdir)
         @input_uri = "file://#{path}"
 
-        # We are writing the images to a location that CarrierWave can upload.
-        #
-        # https://github.com/scientist-softserv/iiif_print/blob/b969541de1a0526305b54de37bf7cf100289f088/lib/iiif_print/jobs/child_works_from_pdf_job.rb#L108
+        # We are writing the images to a local location that CarrierWave can upload.  This is a
+        # local file, internal to IiifPrint; it looks like SpaceStone/DerivativeRodeo lingo, but
+        # that's just a convenience.
         output_template_path = File.join(output_tmp_dir, '{{ dir_parts[-1..-1] }}', '{{ filename }}')
 
         @output_location_template = "file://#{output_template_path}"
-        @preprocessed_location_template = IiifPrint::DerivativeRodeoService.derivative_rodeo_input_uri(file_set: file_set, filename: filename)
+        @preprocessed_location_template = IiifPrint::DerivativeRodeoService.derivative_rodeo_uri(file_set: file_set, filename: filename)
       end
 
       ##
@@ -40,7 +40,9 @@ module IiifPrint
       attr_reader :input_uri
 
       ##
-      # This is the location where we're going to write the derivatives that will "go into Fedora".
+      # This is the location where we're going to write the derivatives that will "go into Fedora";
+      # it is a local location, one that IIIF Print's mounting application can directly do
+      # "File.read"
       #
       # @return [String]
       attr_reader :output_location_template

--- a/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
+++ b/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
@@ -11,16 +11,16 @@ module IiifPrint
     # @see .call
     class DerivativeRodeoSplitter
       ##
-      # @param path [String] the local file location
-      # @param file_set [FileSet] file set containing a PDF file to split
+      # @param filename [String] the local path to the PDFDerivativeServicele
+      # @param file_set [FileSet] file set containing the PDF file to split
       #
       # @return [Array] paths to images split from each page of PDF file
-      def self.call(path, file_set:)
-        new(path, file_set: file_set).split_files
+      def self.call(filename, file_set:)
+        new(filename, file_set: file_set).split_files
       end
 
-      def initialize(path, file_set:, output_tmp_dir: Dir.tmpdir)
-        @input_uri = "file://#{path}"
+      def initialize(filename, file_set:, output_tmp_dir: Dir.tmpdir)
+        @input_uri = "file://#{filename}"
 
         # We are writing the images to a local location that CarrierWave can upload.  This is a
         # local file, internal to IiifPrint; it looks like SpaceStone/DerivativeRodeo lingo, but

--- a/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
+++ b/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
@@ -1,0 +1,71 @@
+module IiifPrint
+  module SplitPdfs
+    ##
+    # This class wraps the DerivativeRodeo::Generators::PdfSplitGenerator to find preprocessed
+    # images, or split a PDF if there are no preprocessed images.
+    #
+    # We have already attached the original file to the file_set.  We want to convert that original
+    # file that's attached to a input_uri (e.g. "file://path/to/original-file" as in what we have
+    # written to Fedora as the PDF)
+    #
+    # @see .call
+    class DerivativeRodeoSplitter
+      ##
+      # @param path [String] the local file location
+      # @param file_set [FileSet] file set containing a PDF file to split
+      #
+      # @return [Array] paths to images split from each page of PDF file
+      def self.call(path, file_set:)
+        new(path, file_set: file_set).split_files
+      end
+
+      def initialize(path, file_set:, output_tmp_dir: Dir.tmpdir)
+        @input_uri = "file://#{path}"
+
+        # We are writing the images to a location that CarrierWave can upload.
+        #
+        # https://github.com/scientist-softserv/iiif_print/blob/b969541de1a0526305b54de37bf7cf100289f088/lib/iiif_print/jobs/child_works_from_pdf_job.rb#L108
+        output_template_path = File.join(output_tmp_dir, '{{ dir_parts[-1..-1] }}', '{{ filename }}')
+
+        @output_location_template = "file://#{output_template_path}"
+        @preprocessed_location_template = IiifPrint::DerivativeRodeoService.derivative_rodeo_input_uri(file_set: file_set, filename: filename)
+      end
+
+      ##
+      # This is where, in "Fedora" we have the original file.  This is not the original file in the
+      # pre-processing location but instead the long-term location of the file in the application
+      # that mounts IIIF Print.
+      #
+      # @return [String]
+      attr_reader :input_uri
+
+      ##
+      # This is the location where we're going to write the derivatives that will "go into Fedora".
+      #
+      # @return [String]
+      attr_reader :output_location_template
+
+      ##
+      # Where can we find, in the DerivativeRodeo's storage, what has already been done regarding
+      # derivative generation.
+      #
+      # For example, SpaceStone::Serverless will pre-process derivatives and write them into an S3
+      # bucket that we then use for IIIF Print.
+      #
+      # @return [String]
+      #
+      # @see https://github.com/scientist-softserv/space_stone-serverless/blob/7f46dd5b218381739cd1c771183f95408a4e0752/awslambda/handler.rb#L58-L63
+      attr_reader :preprocessed_location_template
+
+      ##
+      # @return [Array<Strings>] the paths to each of the images split off from the PDF.
+      def split_files
+        DerivativeRodeo::Generators::PdfSplitGenerator.new(
+          input_uris: [@input_uri],
+          output_location_template: output_location_template,
+          preprocessed_location_template: preprocessed_location_template
+        ).generated_files.map(&:file_path)
+      end
+    end
+  end
+end

--- a/spec/iiif_print/split_pdfs/derivative_rodeo_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/derivative_rodeo_splitter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe IiifPrint::SplitPdfs::DerivativeRodeoSplitter do
   end
 
   describe "instance" do
-    subject { described_class.new(file_set: file_set) }
+    subject { described_class.new(path, file_set: file_set) }
 
     before do
       allow(file_set).to receive(:parent).and_return(work)

--- a/spec/iiif_print/split_pdfs/derivative_rodeo_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/derivative_rodeo_splitter_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe IiifPrint::SplitPdfs::DerivativeRodeoSplitter do
+  let(:path) { nil }
+  let(:work) { double(MyWork, aark_id: '12345') }
+  let(:file_set) { FileSet.new.tap { |fs| fs.save!(validate: false) } }
+
+  describe 'class' do
+    subject { described_class }
+
+    it { is_expected.to respond_to(:call) }
+  end
+
+  describe "instance" do
+    subject { described_class.new(file_set: file_set) }
+
+    before do
+      allow(file_set).to receive(:parent).and_return(work)
+      # TODO: This is a hack that leverages the internals of Hydra::Works; not excited about it but
+      # this part is only one piece of the over all integration.
+      allow(file_set).to receive(:original_file).and_return(double(original_filename: __FILE__))
+    end
+
+    it { is_expected.to respond_to :split_files }
+
+    it 'uses the rodeo to split' do
+      expect(DerivativeRodeo::Generators::PdfSplitGenerator).to receive(:new)
+      described_class.call(path, file_set: file_set)
+    end
+  end
+end

--- a/spec/iiif_print/split_pdfs/derivative_rodeo_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/derivative_rodeo_splitter_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe IiifPrint::SplitPdfs::DerivativeRodeoSplitter do
 
   describe "instance" do
     subject { described_class.new(path, file_set: file_set) }
+    let(:generator) { double(DerivativeRodeo::Generators::PdfSplitGenerator, generated_files: []) }
 
     before do
       allow(file_set).to receive(:parent).and_return(work)
@@ -26,7 +27,7 @@ RSpec.describe IiifPrint::SplitPdfs::DerivativeRodeoSplitter do
     it { is_expected.to respond_to :split_files }
 
     it 'uses the rodeo to split' do
-      expect(DerivativeRodeo::Generators::PdfSplitGenerator).to receive(:new)
+      expect(DerivativeRodeo::Generators::PdfSplitGenerator).to receive(:new).and_return(generator)
       described_class.call(path, file_set: file_set)
     end
   end

--- a/spec/services/iiif_print/derivative_rodeo_service_spec.rb
+++ b/spec/services/iiif_print/derivative_rodeo_service_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe IiifPrint::DerivativeRodeoService do
 
   subject(:klass) { described_class }
 
-  describe '.input_location_adapter_name' do
-    subject { described_class.input_location_adapter_name }
+  describe '.preprocessed_location_adapter_name' do
+    subject { described_class.preprocessed_location_adapter_name }
     it { is_expected.to eq 's3' }
   end
 

--- a/spec/services/iiif_print/derivative_rodeo_service_spec.rb
+++ b/spec/services/iiif_print/derivative_rodeo_service_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe IiifPrint::DerivativeRodeoService do
     it { is_expected.to be_a Hash }
   end
 
-  describe '.derivative_rodeo_input_uri' do
-    subject { described_class.derivative_rodeo_pre_processed_uri(file_set: file_set) }
+  describe '.derivative_rodeo_uri' do
+    subject { described_class.derivative_rodeo_uri(file_set: file_set) }
 
     context 'when the file_set does not have a parent' do
       xit 'is expected to raise an error' do

--- a/spec/services/iiif_print/derivative_rodeo_service_spec.rb
+++ b/spec/services/iiif_print/derivative_rodeo_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe IiifPrint::DerivativeRodeoService do
     context 'when the file_set has a parent' do
       before do
         allow(file_set).to receive(:parent).and_return(work)
-        # TODO: This is a hack that leverages the internals of Hydra::Works; not excited about it but
+        # TODO: This is a hack that leverages the internals oof Hydra::Works; not excited about it but
         # this part is only one piece of the over all integration.
         allow(file_set).to receive(:original_file).and_return(double(original_filename: __FILE__))
       end

--- a/spec/services/iiif_print/derivative_rodeo_service_spec.rb
+++ b/spec/services/iiif_print/derivative_rodeo_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe IiifPrint::DerivativeRodeoService do
   end
 
   describe '.derivative_rodeo_input_uri' do
-    subject { described_class.derivative_rodeo_input_uri(file_set: file_set) }
+    subject { described_class.derivative_rodeo_pre_processed_uri(file_set: file_set) }
 
     context 'when the file_set does not have a parent' do
       xit 'is expected to raise an error' do
@@ -44,7 +44,7 @@ RSpec.describe IiifPrint::DerivativeRodeoService do
         allow(file_set).to receive(:original_file).and_return(double(original_filename: __FILE__))
       end
 
-      it { is_expected.to start_with("#{described_class.input_location_adapter_name}://") }
+      it { is_expected.to start_with("#{described_class.preprocessed_location_adapter_name}://") }
       it { is_expected.to end_with(File.basename(__FILE__)) }
     end
   end
@@ -64,7 +64,7 @@ RSpec.describe IiifPrint::DerivativeRodeoService do
     end
 
     context 'when derivative rodeo has not pre-processed the file set' do
-      before { instance.input_location_adapter_name = "file" }
+      before { instance.preprocessed_location_adapter_name = "file" }
 
       let(:mime_type) { "application/pdf" }
       it { is_expected.to be_falsey }


### PR DESCRIPTION
## 🎁 Add derivative_rodeo_splitter

c6be86fb3e5d6c737317336f168607048c35d1ce

Add a new PDF splitter option that wraps the DerivateRodeo's
PdfSplitGenerator.  It handles, in theory, PDF splitting and the
derivative's generated in the DerivativeRodeo.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/220

Co-authored-by: LaRita Robinson <larita@scientist.com>
Co-authored-by: Shana Moore <shana@scientist.com>
