### PR TITLE
🎁 Add ability to find pages split from a PDF

### DIFF
--- a/iiif_print.gemspec
+++ b/iiif_print.gemspec
@@ -23,7 +23,7 @@ SUMMARY
   spec.files = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.add_dependency 'blacklight_iiif_search', '~> 1.0'
-  spec.add_dependency 'derivative-rodeo', "~> 0.3"
+  spec.add_dependency 'derivative-rodeo', "~> 0.4"
   spec.add_dependency 'dry-monads', '~> 1.4.0'
   spec.add_dependency 'hyrax', '>= 2.5', '< 4'
   spec.add_dependency 'nokogiri', '>=1.13.2'

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -41,12 +41,31 @@ module IiifPrint
   end
 
   ##
+  # Return the immediate parent of the given :file_set.
+  #
   # @param file_set [FileSet]
   # @return [#work?, Hydra::PCDM::Work]
+  # @return [NilClass] when no parent is found.
   def self.parent_for(file_set)
     # fallback to Fedora-stored relationships if work's aggregation of
     #   file set is not indexed in Solr
     file_set.parent || file_set.member_of.find(&:work?)
+  end
+
+  ##
+  # Return the parent's parent of the given :file_set.
+  #
+  # @param file_set [FileSet]
+  # @return [#work?, Hydra::PCDM::Work]
+  # @return [NilClass] when no grand parent is found.
+  def self.grandparent_for(file_set)
+    parent = parent_for(file_set)
+    # HACK: This is an assumption about the file_set structure, namely that an image page split from
+    # a PDF is part of a file set that is a child of a work that is a child of a single work.  That
+    # is, it only has one grand parent.  Which is a reasonable assumption for IIIF Print but is not
+    # valid when extended beyond IIIF Print.  That is GenericWork does not have a parent method but
+    # does have a parents method.
+    parent&.parents&.first || parent&.member_of&.find(:work?)
   end
 
   DEFAULT_MODEL_CONFIGURATION = {

--- a/spec/iiif_print/split_pdfs/derivative_rodeo_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/derivative_rodeo_splitter_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe IiifPrint::SplitPdfs::DerivativeRodeoSplitter do
-  let(:path) { nil }
+  let(:path) { __FILE__ }
   let(:work) { double(MyWork, aark_id: '12345') }
   let(:file_set) { FileSet.new.tap { |fs| fs.save!(validate: false) } }
 

--- a/spec/services/iiif_print/derivative_rodeo_service_spec.rb
+++ b/spec/services/iiif_print/derivative_rodeo_service_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe IiifPrint::DerivativeRodeoService do
   let(:generator) { DerivativeRodeo::Generators::CopyGenerator }
   let(:output_extension) { "rb" }
 
+  before do
+    allow(file_set).to receive(:parent).and_return(work)
+
+    # TODO: This is a hack that leverages the internals oof Hydra::Works; not excited about it but
+    # this part is only one piece of the over all integration.
+    allow(file_set).to receive(:original_file).and_return(double(original_filename: __FILE__))
+  end
+
   let(:instance) { described_class.new(file_set) }
 
   subject(:klass) { described_class }
@@ -28,7 +36,7 @@ RSpec.describe IiifPrint::DerivativeRodeoService do
   end
 
   describe '.derivative_rodeo_uri' do
-    subject { described_class.derivative_rodeo_uri(file_set: file_set) }
+    subject { described_class.derivative_rodeo_uri(file_set: file_set, filename: __FILE__) }
 
     context 'when the file_set does not have a parent' do
       xit 'is expected to raise an error' do
@@ -37,13 +45,6 @@ RSpec.describe IiifPrint::DerivativeRodeoService do
     end
 
     context 'when the file_set has a parent' do
-      before do
-        allow(file_set).to receive(:parent).and_return(work)
-        # TODO: This is a hack that leverages the internals oof Hydra::Works; not excited about it but
-        # this part is only one piece of the over all integration.
-        allow(file_set).to receive(:original_file).and_return(double(original_filename: __FILE__))
-      end
-
       it { is_expected.to start_with("#{described_class.preprocessed_location_adapter_name}://") }
       it { is_expected.to end_with(File.basename(__FILE__)) }
     end


### PR DESCRIPTION
This commit leverages the conventions established in the DerivativeRodeo around where we're writing split pages and their derivatives.

The inline comments that are written/amended with this PR should be read closely for clarity and intention.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/251
- https://github.com/scientist-softserv/derivative_rodeo/pull/48