### PR TITLE
🐛 Ensure `FileSet` id

### DIFF
--- a/lib/iiif_print/blacklight_iiif_search/annotation_decorator.rb
+++ b/lib/iiif_print/blacklight_iiif_search/annotation_decorator.rb
@@ -78,7 +78,10 @@ module IiifPrint
 
         file_set_ids = document['file_set_ids_ssim']
         raise "#{self.class}: NO FILE SET ID" if file_set_ids.blank?
-        file_set_ids.first
+
+        # Since a parent work's `file_set_ids_ssim` can contain child work ids as well as file set ids,
+        # this will ensure that the file set id is indeed a `FileSet`
+        file_set_ids.detect { |id| SolrDocument.find(id).file_set? }
       end
 
       ##

--- a/spec/factories/newspaper_page_solr_document.rb
+++ b/spec/factories/newspaper_page_solr_document.rb
@@ -1,11 +1,19 @@
 FactoryBot.define do
+  factory :file_set_solr_document, class: SolrDocument do
+    initialize_with do
+      new(id: 'fs123456',
+          has_model_ssim: ['FileSet'])
+    end
+  end
+
   factory :newspaper_page_solr_document, class: SolrDocument do
     initialize_with do
+      file_set = build(:file_set_solr_document)
       new(id: '123456',
           title_tesim: ['Page 1'],
           has_model_ssim: ['NewspaperPage'],
           issue_id_ssi: 'abc123',
-          file_set_ids_ssim: ['7891011'],
+          file_set_ids_ssim: [file_set.id],
           thumbnail_path_ss: '/downloads/123456?file=thumbnail')
     end
   end

--- a/spec/iiif_print/blacklight_iiif_search/annotation_decorator_spec.rb
+++ b/spec/iiif_print/blacklight_iiif_search/annotation_decorator_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe IiifPrint::BlacklightIiifSearch::AnnotationDecorator do
                                                    0, nil, controller,
                                                    parent_document)
   end
+  let(:file_set) { build(:file_set_solr_document) }
   let(:test_request) { ActionDispatch::TestRequest.new({}) }
 
   before do
@@ -28,6 +29,7 @@ RSpec.describe IiifPrint::BlacklightIiifSearch::AnnotationDecorator do
     allow(controller).to receive(:polymorphic_url)
       .with(parent_document, host: test_request.base_url, locale: nil)
       .and_return("/#{page_document[:issue_id_ssi]}")
+    allow(SolrDocument).to receive(:find).with(file_set.id).and_return(file_set)
   end
 
   describe '#annotation_id' do


### PR DESCRIPTION
This commit will add assurance that we are getting the FileSet id and not some other work type id.
