### PR TITLE
🐛 I469 adv search then paginate

### DIFF
--- a/app/helpers/iiif_print/iiif_print_helper_behavior.rb
+++ b/app/helpers/iiif_print/iiif_print_helper_behavior.rb
@@ -1,0 +1,22 @@
+module IiifPrint::IiifPrintHelperBehavior
+  ##
+  # print the ocr snippets. if more than one, separate with <br/>
+  #
+  # @param options [Hash] options hash provided by Blacklight
+  # @return [String] snippets HTML to be rendered
+  # rubocop:disable Rails/OutputSafety
+  def render_ocr_snippets(options = {})
+# debugger
+    snippets = options[:value]
+    snippets_content = [content_tag('div',
+                                    "... #{snippets.first} ...".html_safe,
+                                    class: 'ocr_snippet first_snippet')]
+    if snippets.length > 1
+      snippets_content << render(partial: 'catalog/snippets_more',
+                                 locals: { snippets: snippets.drop(1),
+                                           options: options })
+    end
+    snippets_content.join("\n").html_safe
+  end
+  # rubocop:enable Rails/OutputSafety
+end

--- a/app/helpers/iiif_print_helper.rb
+++ b/app/helpers/iiif_print_helper.rb
@@ -41,24 +41,4 @@ module IiifPrintHelper
     end
     hl_matches.uniq.sort.join(' ')
   end
-
-  ##
-  # print the ocr snippets. if more than one, separate with <br/>
-  #
-  # @param options [Hash] options hash provided by Blacklight
-  # @return [String] snippets HTML to be rendered
-  # rubocop:disable Rails/OutputSafety
-  def render_ocr_snippets(options = {})
-    snippets = options[:value]
-    snippets_content = [content_tag('div',
-                                    "... #{snippets.first} ...".html_safe,
-                                    class: 'ocr_snippet first_snippet')]
-    if snippets.length > 1
-      snippets_content << render(partial: 'catalog/snippets_more',
-                                 locals: { snippets: snippets.drop(1),
-                                           options: options })
-    end
-    snippets_content.join("\n").html_safe
-  end
-  # rubocop:enable Rails/OutputSafety
 end

--- a/lib/generators/iiif_print/install_generator.rb
+++ b/lib/generators/iiif_print/install_generator.rb
@@ -30,6 +30,10 @@ module IiifPrint
       generate 'iiif_print:assets'
     end
 
+    def inject_helper
+      copy_file 'helpers/iiif_print_helper.rb'
+    end
+
     # Blacklight IIIF Search generator has some linting that does not agree with CircleCI on Hyku
     # ref https://github.com/boston-library/blacklight_iiif_search/blob/v1.0.0/lib/generators/blacklight_iiif_search/controller_generator.rb
     # the follow two methods does a clean up to appease Rubocop

--- a/lib/generators/iiif_print/templates/helpers/iiif_print_helper.rb
+++ b/lib/generators/iiif_print/templates/helpers/iiif_print_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module IiifPrintHelper
+  include IiifPrint::IiifPrintHelperBehavior
+end


### PR DESCRIPTION
# Story

Refs: https://github.com/scientist-softserv/adventist-dl/issues/469

Method `render_ocr_snippets` was causing AbstractController::DoubleRenderError
() during random situations, due to including the IiifPrintHelper in
ApplicationController.

This pull request moves it into a helper module which is injected by the
install generator, [which matches how it was done in LV](https://github.com/scientist-softserv/louisville-hyku/blob/b672d2a3213aaee84c082eb8083d8ad70733036b/app/helpers/newspaper_works_helper.rb#L3) & NNP. 

# Expected Behavior Before Changes

The app randomly throws AbstractController::DoubleRenderError when viewing the catalog results page.

# Expected Behavior After Changes

The catalog results page which was previously erroring resolves successfully.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-06-29 at 7 10 48 PM](https://github.com/scientist-softserv/iiif_print/assets/17851674/caa20235-1052-4497-b661-279d0d7c121e)

</details>

# Notes