### PR TITLE
🐛 Restore PDF splitting functionality to main and bring in subsequent code changes

### DIFF
--- a/app/actors/iiif_print/actors/file_set_actor_decorator.rb
+++ b/app/actors/iiif_print/actors/file_set_actor_decorator.rb
@@ -9,7 +9,10 @@ module IiifPrint
         super
 
         if from_url
-          service.conditionally_enqueue(file_set: file_set, file: file, import_url: file_set.import_url, user: @user)
+          args = { file_set: file_set, file: file, import_url: file_set.import_url, user: @user }
+          returned_value = service.conditionally_enqueue(**args)
+          Rails.logger.info("Result of #{returned_value} for conditional enqueueing of #{args.inspect}")
+          true
         else
           # we don't have the parent yet... save the paths for later use
           @file = file
@@ -21,7 +24,10 @@ module IiifPrint
         # Locks to ensure that only one process is operating on the list at a time.
         super
 
-        service.conditionally_enqueue(file_set: file_set, work: work, file: @file, user: @user)
+        args = { file_set: file_set, work: work, file: @file, user: @user }
+        returned_value = service.conditionally_enqueue(**args)
+        Rails.logger.info("Result of #{returned_value} for conditional enqueueing of #{args.inspect}")
+        true
       end
 
       def service

--- a/app/helpers/iiif_print/iiif_print_helper_behavior.rb
+++ b/app/helpers/iiif_print/iiif_print_helper_behavior.rb
@@ -1,0 +1,22 @@
+module IiifPrint::IiifPrintHelperBehavior
+  ##
+  # print the ocr snippets. if more than one, separate with <br/>
+  #
+  # @param options [Hash] options hash provided by Blacklight
+  # @return [String] snippets HTML to be rendered
+  # rubocop:disable Rails/OutputSafety
+  def render_ocr_snippets(options = {})
+# debugger
+    snippets = options[:value]
+    snippets_content = [content_tag('div',
+                                    "... #{snippets.first} ...".html_safe,
+                                    class: 'ocr_snippet first_snippet')]
+    if snippets.length > 1
+      snippets_content << render(partial: 'catalog/snippets_more',
+                                 locals: { snippets: snippets.drop(1),
+                                           options: options })
+    end
+    snippets_content.join("\n").html_safe
+  end
+  # rubocop:enable Rails/OutputSafety
+end

--- a/app/helpers/iiif_print_helper.rb
+++ b/app/helpers/iiif_print_helper.rb
@@ -41,24 +41,4 @@ module IiifPrintHelper
     end
     hl_matches.uniq.sort.join(' ')
   end
-
-  ##
-  # print the ocr snippets. if more than one, separate with <br/>
-  #
-  # @param options [Hash] options hash provided by Blacklight
-  # @return [String] snippets HTML to be rendered
-  # rubocop:disable Rails/OutputSafety
-  def render_ocr_snippets(options = {})
-    snippets = options[:value]
-    snippets_content = [content_tag('div',
-                                    "... #{snippets.first} ...".html_safe,
-                                    class: 'ocr_snippet first_snippet')]
-    if snippets.length > 1
-      snippets_content << render(partial: 'catalog/snippets_more',
-                                 locals: { snippets: snippets.drop(1),
-                                           options: options })
-    end
-    snippets_content.join("\n").html_safe
-  end
-  # rubocop:enable Rails/OutputSafety
 end

--- a/lib/generators/iiif_print/install_generator.rb
+++ b/lib/generators/iiif_print/install_generator.rb
@@ -30,6 +30,10 @@ module IiifPrint
       generate 'iiif_print:assets'
     end
 
+    def inject_helper
+      copy_file 'helpers/iiif_print_helper.rb'
+    end
+
     # Blacklight IIIF Search generator has some linting that does not agree with CircleCI on Hyku
     # ref https://github.com/boston-library/blacklight_iiif_search/blob/v1.0.0/lib/generators/blacklight_iiif_search/controller_generator.rb
     # the follow two methods does a clean up to appease Rubocop

--- a/lib/generators/iiif_print/templates/helpers/iiif_print_helper.rb
+++ b/lib/generators/iiif_print/templates/helpers/iiif_print_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module IiifPrintHelper
+  include IiifPrint::IiifPrintHelperBehavior
+end

--- a/lib/iiif_print/split_pdfs/child_work_creation_from_pdf_service.rb
+++ b/lib/iiif_print/split_pdfs/child_work_creation_from_pdf_service.rb
@@ -41,7 +41,7 @@ module IiifPrint
           admin_set_id,
           0 # A no longer used parameter; but we need to preserve the method signature (for now)
         )
-        true
+        :enqueued
       end
       # rubocop:enable Metrics/MethodLength
 

--- a/lib/iiif_print/split_pdfs/child_work_creation_from_pdf_service.rb
+++ b/lib/iiif_print/split_pdfs/child_work_creation_from_pdf_service.rb
@@ -30,7 +30,7 @@ module IiifPrint
         file_locations = if import_url
                            [file.path]
                          else
-                           pdf_paths([file.try(:id)&.to_s].compact)
+                           pdf_paths(files: [file.try(:id)&.to_s].compact)
                          end
         return :no_pdfs if file_locations.empty?
 
@@ -38,7 +38,7 @@ module IiifPrint
           file_set,
           file_locations,
           user,
-          admin_set_id,
+          work.admin_set_id,
           0 # A no longer used parameter; but we need to preserve the method signature (for now)
         )
         :enqueued


### PR DESCRIPTION
# Story

Derivative Rodeo refactoring broke PDF splitting. 

This pull request fixes PDF splitting, and brings in [subsequent changes from the no-rodeo branch](https://github.com/scientist-softserv/iiif_print/pull/255) to bring main back up to date.

Refs 
- https://github.com/scientist-softserv/iiif_print/pull/254 and https://github.com/scientist-softserv/adventist-dl/issues/469
- [Originating commit for bug](https://github.com/scientist-softserv/iiif_print/commit/5df1264d88149bb0f1eb0b7f78569e8e124690c0)


# Expected Behavior Before Changes

PDF splitting was getting ignored.

# Expected Behavior After Changes

PDFs split into viewable child works.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-07-05 at 3 33 11 PM](https://github.com/scientist-softserv/iiif_print/assets/17851674/50b6dcba-8d1a-44d6-862c-05cc87f225bd)

![Screenshot 2023-07-05 at 3 33 18 PM](https://github.com/scientist-softserv/iiif_print/assets/17851674/a0d29b00-7cf3-45f8-a8cc-1a32887e6978)

</details>

# Notes
Exceptions are being swallowed somewhere... the errors this bug caused should have been showing up in either worker logs or sentry, but they didn't. 