### PR TITLE
🐛 Fix word count

### DIFF
--- a/lib/iiif_print/text_extraction/hocr_reader.rb
+++ b/lib/iiif_print/text_extraction/hocr_reader.rb
@@ -84,6 +84,7 @@ module IiifPrint
           # add trailing space to plaintext buffer for between words:
           @text += ' '
           @words.push(@current) if word_complete?
+          @current = nil # clear the current word
         end
 
         def end_line
@@ -120,9 +121,12 @@ module IiifPrint
         #   for current word, and append line endings to plain text:
         #
         # @param name [String] element name.
-        def end_element(_name)
-          end_line if @element_class_name == 'ocr_line'
-          end_word if @element_class_name == 'ocrx_word'
+        def end_element(name)
+          if name == 'span'
+            end_word if @element_class_name == 'ocrx_word'
+            @text += "\n" if @element_class_name.nil?
+          end
+          @element_class_name = nil
         end
 
         # Callback for completion of parsing hOCR, used to normalize generated

--- a/spec/iiif_print/text_extraction/hocr_reader_spec.rb
+++ b/spec/iiif_print/text_extraction/hocr_reader_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe IiifPrint::TextExtraction::HOCRReader do
   describe "outputs text derivative formats" do
     it "outputs plain text" do
       plain_text = reader_minimal.text
-      expect(plain_text.slice(0, 40)).to eq "_A  FEARFUL  ADVENTURE.\n‘The  Missouri. "
+      expect(plain_text.slice(0, 40)).to eq "_A FEARFUL ADVENTURE.\n‘The Missouri. Rep"
       expect(reader_minimal.text).to eq reader_minimal.doc_stream.text
-      expect(reader_minimal.text.size).to eq 831
+      expect(reader_minimal.text.size).to eq 723
     end
 
     it "passes args to WordCoordsBuilder and receives output" do


### PR DESCRIPTION
This commit is basically the IIIF Print version of https://github.com/scientist-softserv/derivative_rodeo/pull/34/commits which should fix the problem of having duplicated word coordinates.

Ref:
  - https://github.com/scientist-softserv/adventist-dl/issues/477

# Story

Word search counts sometimes don't match because coordinates are being duplicated.

# Expected Behavior Before Changes

Word counts are sometimes off.

# Expected Behavior After Changes

Word counts should be accurate.

# Screenshots / Video

<details>
<summary>Before</summary>

<img width="1150" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/1ab20642-a568-4a1f-bfaf-cce2124d0150">

</details>

<details>
<summary>After</summary>

<img width="1149" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/836ddba8-f161-4543-a59e-6f5fbf97bed8">

</details>
