### PR TITLE
🐛 Correct search count

### DIFF
--- a/app/models/iiif_print/iiif_search_response_decorator.rb
+++ b/app/models/iiif_print/iiif_search_response_decorator.rb
@@ -6,6 +6,10 @@ module IiifPrint
       json_results = super
       resources = json_results&.[]('resources')
 
+      resources.delete_if do |resource|
+        resource["on"].include?(IiifPrint::BlacklightIiifSearch::AnnotationDecorator::INVALID_MATCH_TEXT)
+      end
+
       resources&.each do |result_hit|
         next if result_hit['resource'].present?
         result_hit['resource'] = {


### PR DESCRIPTION
[🐛 Correct search count](https://github.com/scientist-softserv/iiif_print/commit/ec4b03ca51fe6466cccbe50dda234b6ccac3424f) 

A funky bug was observed when on a parent work of a PDF, the count was
off by one.  It registers OCR hits as both an OCR hit and a metadata
hit.  This is likely because of adding snippets in the search since all
the file sets' texts need to be indexed on the parent work as well.  The
parent work essentially would double all the texts found.  This commit
is a bit hacky but it removes that extra hit while keeping functionality
for both OCR hits and metadata hits.  This is a  bit of future proofing
since it only would happen in applications with snippets enabled.