### PR TITLE
🐛 Return early for no snippets

### DIFF
--- a/app/helpers/iiif_print/iiif_print_helper_behavior.rb
+++ b/app/helpers/iiif_print/iiif_print_helper_behavior.rb
@@ -6,8 +6,9 @@ module IiifPrint::IiifPrintHelperBehavior
   # @return [String] snippets HTML to be rendered
   # rubocop:disable Rails/OutputSafety
   def render_ocr_snippets(options = {})
-# debugger
     snippets = options[:value]
+    return if snippets.blank?
+
     snippets_content = [content_tag('div',
                                     "... #{snippets.first} ...".html_safe,
                                     class: 'ocr_snippet first_snippet')]


### PR DESCRIPTION
This commit fixes a bug where the `render_snippet` method would return `... ...` when there are no snippets.  This way, in the main application's `app/views/catalog/_index_list_default.html.erb` file, we can do something like:

```erb
<% index_fields(document).each do |field_name, field| -%>
  <% if should_render_index_field? document, field %>
      <div class="search-index-metadata-group metadata-<%= field_name %>">
        <% field_value = doc_presenter.field_value field_name %>
        <%# Don't show the snippets field if it's empty %>
        <% next if field_value.blank? %>
        <dt><%= render_index_field_label document, field: field_name %></dt>
        <dd><%= field_value %></dd>
      </div>
  <% end %>
<% end %>
```

This way the field label doesn't show up if there are no snippets.

# Expected Behavior Before Changes

`... ...` would appear if there were no snippets

# Expected Behavior After Changes

Nothing would appear so in the main application, we can not show the field label.

# Screenshots / Video

<details>
<summary>Before</summary>

<img width="983" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/ecadd4a8-0010-4158-8a1c-19ceadb15cad">

</details>

<details>
<summary>After</summary>

<img width="973" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/33fe6bc3-1c2c-40f8-ad67-7dc08e7c9ac1">

</details>
