### PR TITLE
🐛 Fixing issue with misnamed constant and using variable before declared

### DIFF
--- a/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
+++ b/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
@@ -67,6 +67,14 @@ module IiifPrint
           output_location_template: output_location_template,
           preprocessed_location_template: preprocessed_location_template
         ).generated_files.map(&:file_path)
+      rescue => e
+        message = "🤠🐮 #{self.class}##{__method__} encountered `#{e.class}' “#{e}” for " \
+                  "input_uri: #{@input_uri.inspect}, " \
+                  "output_location_template: #{output_location_template.inspect}, and" \
+                  "preprocessed_location_template: #{preprocessed_location_template.inspect}."
+        exception = RuntimeError.new(message)
+        exception.set_backtrace(e.backtrace)
+        raise exception
       end
     end
   end


### PR DESCRIPTION
This commit contains four primary changes:

1. Fixing a misnamed constant.
2. Moving setting the optional filename to a point before we use the filename.
3. Leveraging if include instead of case statements
4. Adding exception decorating to provide additional context.

Of these, the quality of debugging change to exceptions pays the most dividends.  It's helped provide insight into the specific URI that's failing.

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56