### PR TITLE
🐛 Adding more robust (albeit hacky) handling of ancestors

### DIFF
--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -59,13 +59,15 @@ module IiifPrint
   # @return [#work?, Hydra::PCDM::Work]
   # @return [NilClass] when no grand parent is found.
   def self.grandparent_for(file_set)
-    parent = parent_for(file_set)
+    parent_of_file_set = parent_for(file_set)
     # HACK: This is an assumption about the file_set structure, namely that an image page split from
     # a PDF is part of a file set that is a child of a work that is a child of a single work.  That
     # is, it only has one grand parent.  Which is a reasonable assumption for IIIF Print but is not
     # valid when extended beyond IIIF Print.  That is GenericWork does not have a parent method but
     # does have a parents method.
-    parent&.parents&.first || parent&.member_of&.find(:work?)
+    parent_of_file_set.try(:parent_works).try(:first) ||
+      parent_of_file_set.try(:parents).try(:first) ||
+      parent_of_file_set&.member_of&.find(&:work?)
   end
 
   DEFAULT_MODEL_CONFIGURATION = {

--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -113,6 +113,7 @@ module IiifPrint
       end
 
       def create_uploaded_file(user, path)
+        # TODO: Could we create a remote path?
         uf = Hyrax::UploadedFile.new
         uf.user_id = user.id
         uf.file = CarrierWave::SanitizedFile.new(path)


### PR DESCRIPTION
This commit includes three substantive changes:

- Extracting a method for determining the directory in which to look for a file.
- Addressing a very odd bug found in `public_send` behavior.
- Adding a fallback when we don't have an ancestor.

First, the fallback.  It is hacky (as noted by the `HACK:` comment). But it's quick and for Adventist is suitable.  We could extract a function that is the fallback and then call that.

Second, the odd bug manifested as `nil` being raised as an exception; that is to say with the original `rescue => e` the `e` was `nil` (and it's class was `NilClass`).

I found that if I removed the
`IiifPrint.public_set(ancestor_method, file_set)` and made an explicit call, then the exception went away; albeit now returning `nil`.

Which leads to the `HACK:` for handling `nil`.

Last, in extracting the method, I leave a public place for more specific handling of the possible directory for the preprocessed derivative files.

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56