### PR TITLE
🎁 Make representative media alt text dynamic

### DIFF
--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -5,5 +5,6 @@
     <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter %>
   <% end %>
 <% else %>
-  <%= image_tag 'default.png', class: "canonical-image", alt: 'default representative image' %>
+  <% alt = block_for(name: 'default_work_image_text') || 'Default work thumbnail' %>
+  <%= image_tag default_work_image, class: "canonical-image", alt: alt %>
 <% end %>


### PR DESCRIPTION
This commit will modify the _representative_media partial to acknowledge the alt text of the image if it exists.

# Screenshots / Video

<img width="1419" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/55b45b95-373a-45e7-8de9-49a370ccefe8">
