### PR TITLE
🐛 Handle no file_set_ids property

### DIFF
--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -22,7 +22,7 @@ module IiifPrint
     # by not loading more member_presenters than needed.
     def members_include_viewable_image?
       all_member_ids = (solr_document.try(:file_set_ids) || solr_document.try(:[], 'file_set_ids_ssim'))
-      all_member_ids.each do |id|
+      Array.wrap(all_member_ids).each do |id|
         return true if file_type_and_permissions_valid?(member_presenters_for([id]).first)
       end
       false


### PR DESCRIPTION
Prior to this commit, if the preceding line returned `nil` (which I was in tests) the method would raise a `NoMethodError` (nil does not respond to each)

With this commit, we wrap the value into an array thus avoiding the error.

Related to:

- https://github.com/scientist-softserv/palni-palci/pull/675