### PR TITLE
🐛 Render thumbnails when IIIF Print disabled

### DIFF
--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,5 +1,5 @@
 <% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
-  <% if defined?(viewer) && viewer && presenter.iiif_viewer?%>
+  <% if defined?(viewer) && viewer && presenter.iiif_viewer? %>
     <%= iiif_viewer_display presenter %>
   <% else %>
     <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter %>

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,5 +1,5 @@
-<% if presenter.iiif_viewer? %>
-  <% if defined?(viewer) && viewer %>
+<% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
+  <% if defined?(viewer) && viewer && presenter.iiif_viewer?%>
     <%= iiif_viewer_display presenter %>
   <% else %>
     <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter %>


### PR DESCRIPTION
Prior to this commit, the logic brough by IIIF Print was:

```html
<% if presenter.iiif_viewer? %>
  <% if defined?(viewer) && viewer %>
    <%= iiif_viewer_display presenter %>
  <% else %>
    <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter %>
  <% end %>
<% else %>
  <% alt = block_for(name: 'default_work_image_text') || 'Default work thumbnail' %>
  <%= image_tag default_work_image, class: "canonical-image", alt: alt %>
<% end %>
```

We would check if we should use the IIIF viewer.  And because we'd disabled it for the tenant, the answer was no.  The fallback was to then render a default thumbnail.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/276
- https://github.com/scientist-softserv/palni-palci/issues/715
- https://github.com/scientist-softserv/palni-palci/pull/716

Closes: #276
