### PR TITLE
🐛 Fix calling Fedora from view

### DIFF
--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -32,7 +32,8 @@
       <%= link_to 'Download', hyrax.download_path(file_set),
         title: "Download #{file_set.to_s.inspect}", target: "_blank" %>
     </li>
-    <% IiifPrint::Data::WorkDerivatives.new(file_set.id).keys.each do |name| %>
+    <% work_deriv = IiifPrint::Data::WorkDerivatives.new(fileset: file_set) %>
+    <% work_deriv.keys.each do |name| %>
       <li role="menuitem" tabindex="-1">
         <a href="<%= "/downloads/#{file_set.id}?locale=en&file=#{name}" %>" download>
           Download <em>(as <%= name %>)</em>

--- a/lib/iiif_print/data/work_derivatives.rb
+++ b/lib/iiif_print/data/work_derivatives.rb
@@ -47,11 +47,11 @@ module IiifPrint
 
       # alternate constructor spelling:
       def self.of(work, fileset = nil, parent = nil)
-        new(work, fileset, parent)
+        new(work: work, fileset: fileset, parent: parent)
       end
 
       # Adapt work and either specific or first fileset
-      def initialize(work, fileset = nil, parent = nil)
+      def initialize(work: nil, fileset: nil, parent: nil)
         # adapted context usually work, may be string id of FileSet
         @work = work
         @fileset = fileset.nil? ? first_fileset : fileset

--- a/lib/iiif_print/data/work_derivatives.rb
+++ b/lib/iiif_print/data/work_derivatives.rb
@@ -42,7 +42,7 @@ module IiifPrint
       #
       # @return [String]
       def self.data(from:, of_type:)
-        new(from).data(of_type)
+        new(work: from).data(of_type)
       end
 
       # alternate constructor spelling:


### PR DESCRIPTION
This commit will remove the Fedora call from the view.  Instead of passing in the presenter id, we will pass in the presenter object.  This then doesn't make the WorkDerivative look for the first file_set which is where the Fedora call is.

Ref:
  - https://github.com/scientist-softserv/iiif_print/issues/273
