### PR TITLE
♻️ Ensure we pass query to IIIF viewer

### DIFF
--- a/app/helpers/iiif_print/application_helper.rb
+++ b/app/helpers/iiif_print/application_helper.rb
@@ -1,5 +1,25 @@
 module IiifPrint
   # Application Helper module
   module ApplicationHelper
+    ##
+    # This is in place to coerce the :q string to :query for passing the :q value to the query value
+    # of a IIIF Print manifest.
+    #
+    # @param doc [SolrDocument]
+    # @param request [ActionDispatch::Request]
+    #
+    # @return [String]
+    def generate_work_url(doc, request)
+      url = super
+      return url if request.params[:q].blank?
+
+      key = doc.any_highlighting? ? 'parent_query' : 'query'
+      query = { key => request.params[:q] }.to_query
+      if url.include?("?")
+        url + "&#{query}"
+      else
+        url + "?#{query}"
+      end
+    end
   end
 end

--- a/spec/helpers/iiif_print/application_helper_spec.rb
+++ b/spec/helpers/iiif_print/application_helper_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ApplicationHelper do
+  let(:helper) { _view }
+
+  let(:cname) { 'hyku-me.test' }
+  let(:account) { build(:search_only_account, cname: cname) }
+
+  let(:uuid) { SecureRandom.uuid }
+  let(:request) do
+    instance_double(ActionDispatch::Request,
+                    port: 3000,
+                    protocol: "https://",
+                    host: account.cname,
+                    params: { q: q })
+  end
+  let(:doc) { SolrDocument.new(id: uuid, 'has_model_ssim': ['GenericWork'], 'account_cname_tesim': account.cname) }
+
+  before do
+    allow(helper).to receive(:current_account) { account }
+  end
+
+  describe '#generate_work_url' do
+    context 'when params has a "q" parameter' do
+      let(:q) { "wonka-vision" }
+
+      context 'when any_highlighting? is false' do
+        it 'passes that along as :query' do
+          expect(doc).to receive(:any_highlighting?).and_return(false)
+          expect(helper.generate_work_url(doc, request)).to end_with("?query=#{q}")
+        end
+      end
+
+      context 'when any_highlighting? is true' do
+        it 'passes that along as :parent_query' do
+          expect(doc).to receive(:any_highlighting?).and_return(true)
+          expect(helper.generate_work_url(doc, request)).to end_with("?parent_query=#{q}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the later versions of Hyku, they override the Hyrax view of
`app/views/catalog/_index_header_list_default.html.erb`; so IIIF Print's
strategy of overriding that view does not work.  (Because Hyku's view
path rightly takes higher precedence than any Gem).

Looking at the updated view, the URL is generated via a helper method.
So our approach to adding the parent_query or query parameter leverages
extending the helper method.

We still need the view override, as it reflects a prior state of
Hyku (and Hyrax) that some implementations will continue to use.

Below is a *diff of the files in Hyku v5.0.1 and IIIF Print*.  I
have not resolved all of these things but am close:

<details>
<summary>diff of the files in Hyku v5.0.1 and IIIF Print</summary>

```
❯ diff hyrax-webapp/app/views/catalog/_index_header_list_default.html.erb ../iiif_print/app/views/catalog/_index_header_list_default.html.erb
1,2c1,2
< <%# OVERRIDE Hyrax 3.4.0 to support shared search %>
< <% model = document.hydra_model %>
---
> <%# OVERRIDE Hyrax 2.9.6 to show parent_query params if metadata is found in parent record %>
>
4,9c4,12
<     <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
<         <h4 class="search-result-title"><%= link_to document.title_or_label, generate_work_url(document, request) %></h4>
<         <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
<     <% else %>
<         <h4 class="search-result-title"><%= link_to document.title_or_label, generate_work_url(document, request) %></h4>
<     <% end %>
---
>   <h3 class="search-result-title">
>   <% if params['q'].present? && document.any_highlighting? %>
>     <%= link_to document.title_or_label, [document, { parent_query: params['q'] }] %></h3>
>   <% elsif params['q'].present? %>
>     <%= link_to document.title_or_label, [document, { query: params['q'] }] %></h3>
>   <% else %>
>     <%= link_to document.title_or_label, document %></h3>
>   <% end %>
>   </h3>
```

</details>

Co-authored-by: Kirk Wang <kirk.wang@scientist.com>