### PR TITLE
🧹 Add Solargraph as dependency

### DIFF
--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,19 @@
+include:
+- "**/*.rb"
+exclude:
+- spec/**/*
+- test/**/*
+- vendor/**/*
+- ".bundle/**/*"
+require:
+- derivative-rodeo
+- hyrax
+- iiif-presentation
+- iiif_manifest
+- blacklight_iiif_search
+- blacklight
+domains: []
+reporters:
+- rubocop
+- require_not_found
+max_files: 5000

--- a/iiif_print.gemspec
+++ b/iiif_print.gemspec
@@ -41,4 +41,6 @@ SUMMARY
   spec.add_development_dependency 'rspec-activemodel-mocks'
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
   spec.add_development_dependency 'solr_wrapper', '>= 1.1', '< 3.0'
+  spec.add_development_dependency 'solargraph'
+  spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
I have used the following to get jump to definition and render
documentation for the symbol at cursor.

1.  Add solargraph as a development dependency
2.  Run `bundle`
3.  Run `bundle exec yard gems` (or target specific gems)
4.  Add "relevant" gems to the `.solargraph.yml`

The above should *not* be in the docker container.  You would run this
in the environment where your editor is running.  There is probably a
way to make that work with Docker, but I’m not here for that today.