### PR TITLE
Create Child Works based on PDF fileset's file

### DIFF
--- a/lib/iiif_print/split_pdfs/child_work_creation_from_pdf_service.rb
+++ b/lib/iiif_print/split_pdfs/child_work_creation_from_pdf_service.rb
@@ -28,7 +28,7 @@ module IiifPrint
         return :no_split_for_parent unless iiif_print_split?(work: work)
         return :no_pdfs_for_import_url if import_url && !pdfs?(paths: [import_url])
         file_locations = if import_url
-                           [file.path]
+                           [Hyrax::WorkingDirectory.find_or_retrieve(file.id, file_set.id)]
                          else
                            pdf_paths(files: [file.try(:id)&.to_s].compact)
                          end


### PR DESCRIPTION
# Story

The incoming path has been using a temp file location which no longer exists when the ChildWorksFromPdfJob runs, so child works have not been created during the imports using derivative rodeo.

This change uses the fileset's actual file to trigger the child works creation behavior.

# Expected Behavior Before Changes

# Expected Behavior After Changes

When a PDF is attached to a work, the child works are successfully created. 

PDF splitting is expected to complete normally, whether via a standard Bulkrax import, an import using files from SpaceStone, or a UI import.

Sample test via this OAI import: https://adl.s2.adventistdigitallibrary.org/importers/108?locale=e