### PR TITLE
🎁  Service to split previously ingested pdf

### DIFF
--- a/lib/iiif_print/split_pdfs/pdf_child_works_service.rb
+++ b/lib/iiif_print/split_pdfs/pdf_child_works_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module IiifPrint
+  module SplitPdfs
+    ## Encapsulates logic for cleanup when the PDF is destroyed after pdf splitting into child works
+    class PdfChildWorksService
+      def self.create_pdf_child_works_for(file_set:, user:)
+        locations = pdfs_only_for([Hyrax::WorkingDirectory.find_or_retrieve(file.id, file_set.id)])
+        return if locations.empty?
+        work = file_set.parent
+
+        # clean up any existing spawned child works of this file_set
+        IiifPrint::SplitPdfs::DestroyPdfChildWorksService.conditionally_destroy_spawned_children_of(
+          file_set: file_set,
+          work: work
+        )
+
+        # submit a job to split pdf into child works
+        work.iiif_print_config.pdf_splitter_job.perform_later(
+          file_set,
+          locations,
+          user,
+          work.admin_set_id,
+          0 # A no longer used parameter; but we need to preserve the method signature (for now)
+        )
+      end
+
+      # @todo: can we use mimetype instead?
+      def self.pdfs_only_for(paths)
+        paths.select { |path| path.end_with?('.pdf', '.PDF') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Note: This is currently an untested WIP but is based on two known working pieces.

# Story

This creates a new service which combines:
- IiifPrint::SplitPdfs::DestroyPdfChildWorksService
- IiifPring::Jobs::ChildWorksFromPdfJob

Beginning with a PDF fileset, it removes any existing child works (found by either the fileset ID or the title), any pending relationship table entries (found by parent id and fileset ID), and then submits a new job to do the pdf splitting.

Note that pending relationship entries will not be removed if they don't have the file_id (which is the id of the fileset that spawned them). This is to avoid removing pending relationships that could still be needed for another fileset on the parent work.