### PR TITLE
Report errors and ensure file exists

### DIFF
--- a/app/actors/iiif_print/actors/file_set_actor_decorator.rb
+++ b/app/actors/iiif_print/actors/file_set_actor_decorator.rb
@@ -2,8 +2,8 @@
 
 # override to add PDF splitting for file sets and remove splitting upon fileset delete
 
-# Depending on whether we have an uploaded file or a remote url, the sequence of calling 
-# attach_to_work and create_content will switch.  
+# Depending on whether we have an uploaded file or a remote url, the sequence of calling
+# attach_to_work and create_content will switch.
 module IiifPrint
   module Actors
     module FileSetActorDecorator


### PR DESCRIPTION
# Story

Even though the file is put into the correct path location during the child_work_creation_from_pdf_service, we sometimes were finding that the file did not exist at the point we needed it (when running larger import batches). This change:
- ensures the file exists at the path
- reports if no image_files are found to split into

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes