### PR TITLE
🐛 Fix install location for helpers/iiif_print_helper

### DIFF
--- a/lib/generators/iiif_print/install_generator.rb
+++ b/lib/generators/iiif_print/install_generator.rb
@@ -31,7 +31,7 @@ module IiifPrint
     end
 
     def inject_helper
-      copy_file 'helpers/iiif_print_helper.rb'
+      copy_file 'helpers/iiif_print_helper.rb' 'app/helpers/iiif_print_helper.rb'
     end
 
     # Blacklight IIIF Search generator has some linting that does not agree with CircleCI on Hyku


### PR DESCRIPTION
Prior to this commit, the `helpers/iiif_print_helper.rb` file installed
in `Rails.root + /helpers/iiif_print_helper.rb`; it should be in
`app/helpers/iiif_print_helper.rb`