### PR TITLE
🐛 Work through fallback of rodeo URLs

### DIFF
--- a/app/services/iiif_print/derivative_rodeo_service.rb
+++ b/app/services/iiif_print/derivative_rodeo_service.rb
@@ -144,6 +144,7 @@ module IiifPrint
     # @param filename [String]
     # @return [String] the dirname (without any "/" we hope)
     # @return [NilClass] when we cannot infer a URI from the object.
+    # rubocop:disable Metrics/MethodLength
     def self.derivative_rodeo_preprocessed_directory_for(file_set:, filename:)
       ancestor, ancestor_type = get_ancestor(filename: filename, file_set: file_set)
 
@@ -171,6 +172,7 @@ module IiifPrint
       end
       # rubocop:enable Style/GuardClause
     end
+    # rubocop:enable Metrics/MethodLength
 
     def initialize(file_set)
       @file_set = file_set

--- a/app/services/iiif_print/derivative_rodeo_service.rb
+++ b/app/services/iiif_print/derivative_rodeo_service.rb
@@ -82,7 +82,8 @@ module IiifPrint
     # @param adapter_name [String] Added as a parameter to make testing just a bit easier.  See
     #        {.preprocessed_location_adapter_name}
     #
-    # @return [String]
+    # @return [String] when we have a possible candidate.
+    # @return [NilClass] when we could not derive a candidate.
     # rubocop:disable Metrics/MethodLength
     def self.derivative_rodeo_uri(file_set:, filename: nil, extension: nil, adapter_name: preprocessed_location_adapter_name)
       # TODO: This is a hack that knows about the inner workings of Hydra::Works, but for
@@ -91,6 +92,7 @@ module IiifPrint
       filename ||= Hydra::Works::DetermineOriginalName.call(file_set.original_file)
 
       dirname = derivative_rodeo_preprocessed_directory_for(file_set: file_set, filename: filename)
+      return nil unless dirname
 
       # The aforementioned filename and the following basename and extension are here to allow for
       # us to take an original file and see if we've pre-processed the derivative file.  In the
@@ -141,6 +143,7 @@ module IiifPrint
     # @param file_set [FileSet]
     # @param filename [String]
     # @return [String] the dirname (without any "/" we hope)
+    # @return [NilClass] when we cannot infer a URI from the object.
     def self.derivative_rodeo_preprocessed_directory_for(file_set:, filename:)
       ancestor, ancestor_type = get_ancestor(filename: filename, file_set: file_set)
 
@@ -152,16 +155,19 @@ module IiifPrint
         message = "#{self.class}.#{__method__} #{file_set.class} ID=#{file_set.id} and filename: #{filename.inspect}" \
                   "has #{ancestor_type} of #{ancestor.class} ID=#{ancestor.id}"
         Rails.logger.info(message)
-        ancestor.public_send(parent_work_identifier_property_name) ||
-          raise("Expected #{ancestor.class} ID=#{ancestor.id} (#{ancestor_type} of #{file_set.class} ID=#{file_set.id}) " \
-                "to have a present #{parent_work_identifier_property_name.inspect}")
+        parent_work_identifier = ancestor.public_send(parent_work_identifier_property_name)
+        return parent_work_identifier if parent_work_identifier.present?
+        Rails.logger.warn("Expected #{ancestor.class} ID=#{ancestor.id} (#{ancestor_type} of #{file_set.class} ID=#{file_set.id}) " \
+                          "to have a present #{parent_work_identifier_property_name.inspect}")
+        nil
       else
         # HACK: This makes critical assumptions about how we're creating the title for the file_set;
         # but we don't have much to fall-back on.  Consider making this a configurable function.  Or
         # perhaps this entire method should be more configurable.
         # TODO: Revisit this implementation.
-        file_set.title.first.split(".").first ||
-          raise("#{file_set.class} ID=#{file_set.id} has title #{file_set.title.first} from which we cannot infer information.")
+        candidate = file_set.title.first.split(".").first
+        return candidate if candidate.present?
+        nil
       end
       # rubocop:enable Style/GuardClause
     end

--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -66,7 +66,7 @@ module IiifPrint
                 "pdf_file_set #{pdf_file_set.inspect}"
         end
 
-        @split_from_pdf_id = pdf_file_set.nil? ? nil : pdf_file_set.id
+        @split_from_pdf_id = pdf_file_set&.id
         prepare_import_data(original_pdf_path, image_files, user)
 
         # submit the job to create all the child works for one PDF

--- a/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
+++ b/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
@@ -84,7 +84,13 @@ module IiifPrint
         derivative_rodeo_candidate = IiifPrint::DerivativeRodeoService.derivative_rodeo_uri(file_set: file_set, filename: filename)
 
         @preprocessed_location_template =
-          if rodeo_conformant_uri_exists?(derivative_rodeo_candidate)
+          if derivative_rodeo_candidate.blank?
+            message = "#{self.class}##{__method__} could not establish derivative_rodeo_candidate for " \
+                      "#{file_set.class} ID=#{file_set&.id} #to_param=#{file_set&.to_param} with filename #{filename.inspect}.  " \
+                      "Move along little buddy."
+            Rails.logger.debug(message)
+            nil
+          elsif rodeo_conformant_uri_exists?(derivative_rodeo_candidate)
             Rails.logger.debug("#{self.class}##{__method__} found existing file at location #{derivative_rodeo_candidate}.  High five partner!")
             derivative_rodeo_candidate
           elsif file_set.import_url
@@ -94,7 +100,8 @@ module IiifPrint
             handle_original_file_not_in_derivative_rodeo
           else
             message = "#{self.class}##{__method__} could not find an existing file at #{derivative_rodeo_candidate} " \
-                      "nor a remote_url for #{file_set.class} ID=#{file_set.id}.  Returning `nil' as we have no possible preprocess.  " \
+                      "nor a remote_url for #{file_set.class} ID=#{file_set.id} #to_param=#{file_set&.to_param}.  " \
+                      "Returning `nil' as we have no possible preprocess.  " \
                       "Maybe the input_uri #{input_uri.inspect} will be adequate."
             Rails.logger.warn(message)
             nil
@@ -146,7 +153,7 @@ module IiifPrint
       rescue => e
         message = "#{self.class}##{__method__} encountered `#{e.class}' “#{e}” for " \
                   "input_uri: #{input_uri.inspect}, " \
-                  "output_location_template: #{output_location_template.inspect}, and" \
+                  "output_location_template: #{output_location_template.inspect}, and " \
                   "preprocessed_location_template: #{preprocessed_location_template.inspect}."
         exception = RuntimeError.new(message)
         exception.set_backtrace(e.backtrace)

--- a/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
+++ b/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
@@ -78,6 +78,7 @@ module IiifPrint
       #
       # @see https://github.com/scientist-softserv/space_stone-serverless/blob/7f46dd5b218381739cd1c771183f95408a4e0752/awslambda/handler.rb#L58-L63
       # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize
       def preprocessed_location_template
         return @preprocessed_location_template if defined?(@preprocessed_location_template)
 
@@ -107,6 +108,7 @@ module IiifPrint
             nil
           end
       end
+      # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
 
       ##

--- a/lib/iiif_print/split_pdfs/destroy_pdf_child_works_service.rb
+++ b/lib/iiif_print/split_pdfs/destroy_pdf_child_works_service.rb
@@ -12,7 +12,7 @@ module IiifPrint
         return unless child_model
         return unless file_set.class.pdf_mime_types.include?(file_set.mime_type)
 
-        IiifPrint::PendingRelationship.where(parent_id: work.id, file_id: file_set.id).each(&:destroy)
+        IiifPrint::PendingRelationship.where(parent_id: work.id, file_id: file_set.id).find_each(&:destroy)
         destroy_spawned_children(model: child_model, file_set: file_set, work: work)
       end
 


### PR DESCRIPTION
This commit replaces raising exceptions when we can't derive the URL. Instead it opts to return nil and let the caller determine what to do.

The primary result is that it's easier to have a rodeo configuration "miss" finding files in the pre-process location due to configuration issues.

But alas, that's the nature of a rodeo.

Related to:

- https://github.com/scientist-softserv/iiif_print/issues/294
