### PR TITLE
🎁 Introduce .named_derivatives_and_generators_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,19 @@ The [DerivativeRodeo](https://github.com/scientist-softserv/derivative_rodeo) al
 
 By default the preprocess location is S3, as that is where SoftServ has been running pre-processing.  However that default may not be adequate for local development.
 
+#### Conditional Derivative Generation
+
+The [IiifPrint::DerivativeRodeoService][./app/services/iiif_print/derivative_rodeo_service.rb] provides a means of specifying the derivatives to generate via two configuration points:
+
+- `IiifPrint::DerivativeRodeoService.named_derivatives_and_generators_by_type`
+- `IiifPrint::DerivativeRodeoService.named_derivatives_and_generators_filter`
+
+In the case of `named_derivatives_and_generators_by_type`, we're saying all mime categories will generate these derivatives.
+
+In the case of `named_derivatives_and_generators_filter`, we're providing a point where we can specify for each file_set and filename the specific derivatives to accept/reject/append to the named derivative generation.
+
+See their examples for further configuration guidance.
+
 # Ingesting Content
 
 IiifPrint supports a range of different ingest workflows:

--- a/lib/iiif_print/errors.rb
+++ b/lib/iiif_print/errors.rb
@@ -18,4 +18,10 @@ module IiifPrint
       super(message)
     end
   end
+
+  class UnexpectedMimeTypeError < IiifPrintError
+    def initialize(file_set:, mime_type:)
+      super "Unexpected mime_type #{mime_type} for #{file_set.class} ID=#{file_set.id.inspect}"
+    end
+  end
 end

--- a/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
+++ b/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb
@@ -71,7 +71,7 @@ module IiifPrint
       # bucket that we then use for IIIF Print.
       #
       # @note The preprocessed_location_template should end in `.pdf`.  The
-      #       {DerivativeRodeo::BaseGenerator::PdfSplitGenerator#derive_preprocessed_template_from}
+      #       DerivativeRodeo::BaseGenerator::PdfSplitGenerator#derive_preprocessed_template_from
       #       will coerce the template into one that represents the split pages.
       #
       # @return [String]


### PR DESCRIPTION
Prior to this commit, IIIF Print assumed that every file of a given
mime-type would use all of the same generators.  However, that is not
necessarily the case.

With this commit:

- Updated documentation based on a read of the generated Yardoc
- Added `DerivativeRodeoService.named_derivatives_and_generators_filter`
- Added a `clone` of attributes

The clone is in place to help ensure that as we apply the filter we
don't accidentally delete the application's configuration for mime
category and expected derivatives.

For example, let's say I have the following nested hash:

```ruby
nested_hash = {
  pdf: {
    thumbnail: "DerivativeRodeo::Generators::ThumbnailGenerator"
  },
  image: {
    thumbnail: "DerivativeRodeo::Generators::ThumbnailGenerator",
    json: "DerivativeRodeo::Generators::WordCoordinatesGenerator",
    xml: "DerivativeRodeo::Generators::AltoGenerator",
    txt: "DerivativeRodeo::Generators::PlainTextGenerator"
  }
}
```

If I then call the following:

```ruby
nested_hash.fetch(:pdf).delete_if { |key, value| key == :thumbnail }
```

Then look at `nested_hash`, I will see the following:

```ruby
pp nested_hash

{:pdf=>{},
 :image=>
  {:thumbnail=>"DerivativeRodeo::Generators::ThumbnailGenerator",
   :json=>"DerivativeRodeo::Generators::WordCoordinatesGenerator",
   :xml=>"DerivativeRodeo::Generators::AltoGenerator",
   :txt=>"DerivativeRodeo::Generators::PlainTextGenerator"}}
```

Why? Because we haven't changed objects.  It's possible that Rails's
class_attribute will do deep clones of hashes, but with this clone
behavior we remove that possibility of a problem.

Related to:

- https://github.com/scientist-softserv/adventist-dl/pull/684
- https://github.com/scientist-softserv/adventist-dl/issues/676