### PR TITLE
🐛 Favor `_ssi` field over `_tsi` for split from PDF

### DIFF
--- a/app/indexers/concerns/iiif_print/child_indexer.rb
+++ b/app/indexers/concerns/iiif_print/child_indexer.rb
@@ -26,7 +26,7 @@ module IiifPrint
     def generate_solr_document
       super.tap do |solr_doc|
         solr_doc['is_child_bsi'] ||= object.is_child
-        solr_doc['split_from_pdf_id_tsi'] ||= object.split_from_pdf_id
+        solr_doc['split_from_pdf_id_ssi'] ||= object.split_from_pdf_id
         solr_doc['is_page_of_ssim'] = iiif_print_lineage_service.ancestor_ids_for(object)
 
         # Due to a long-standing hack in Hyrax, the file_set_ids_ssim contains both file_set_ids and

--- a/app/models/concerns/iiif_print/solr/document.rb
+++ b/app/models/concerns/iiif_print/solr/document.rb
@@ -19,7 +19,7 @@ module IiifPrint::Solr::Document
   def self.decorate(base)
     base.prepend(self)
     base.send(:attribute, :is_child, Hyrax::SolrDocument::Metadata::Solr::String, 'is_child_bsi')
-    base.send(:attribute, :split_from_pdf_id, Hyrax::SolrDocument::Metadata::Solr::String, 'split_from_pdf_id_tsi')
+    base.send(:attribute, :split_from_pdf_id, Hyrax::SolrDocument::Metadata::Solr::String, 'split_from_pdf_id_ssi')
     base.send(:attribute, :digest, Hyrax::SolrDocument::Metadata::Solr::String, 'digest_ssim')
 
     # @note These properties came from the newspaper_works gem.  They are configurable.


### PR DESCRIPTION
As a `_tsi` it's tokenized and we can't use it reliably for join
queries.

As an `_ssi` the following Solr `q` value will allow me to query all
documents that have an `application/pdf` mime_type (e.g. a FileSet) and
do not have child works that were split from the given PDF.

```
mime_type_ssi:application/pdf AND
-_query_:"{!v='id:split_from_pdf_id_tsi'}"
```

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/681