### PR TITLE
🎁 Add config for skipping splitting by file suffix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,6 @@ GEM
       representable (>= 2.4.0, <= 3.1.0)
       uber (< 0.2.0)
     docile (1.4.0)
-    domain_name (0.6.20231109)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -307,9 +306,6 @@ GEM
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
     ffi (1.16.3)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
-      rake
     flipflop (2.7.1)
       activesupport (>= 4.0)
       terminal-table (>= 1.8)
@@ -344,14 +340,6 @@ GEM
     hashie (5.0.0)
     hiredis (0.6.3)
     htmlentities (4.3.4)
-    http (5.1.1)
-      addressable (~> 2.8)
-      http-cookie (~> 1.0)
-      http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.4.0)
-    http-cookie (1.0.5)
-      domain_name (~> 0.5)
-    http-form_data (2.3.0)
     http_logger (0.7.0)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
@@ -566,9 +554,6 @@ GEM
       shex (~> 0.6, >= 0.6.4)
       sparql (~> 3.1, >= 3.1.8)
       sparql-client (~> 3.1, >= 3.1.2)
-    llhttp-ffi (0.4.0)
-      ffi-compiler (~> 1.0)
-      rake (~> 13.0)
     logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -590,7 +575,6 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitar (0.9)
     minitest (5.20.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -835,6 +819,7 @@ GEM
       oauth2
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.7.4)
@@ -900,11 +885,11 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
-    solr_wrapper (4.0.2)
-      http
-      minitar
+    solr_wrapper (2.2.0)
+      faraday
       retriable
       ruby-progressbar
+      rubyzip
     sparql (3.2.6)
       builder (~> 3.2, >= 3.2.4)
       ebnf (~> 2.3, >= 2.3.5)

--- a/README.md
+++ b/README.md
@@ -187,6 +187,16 @@ To remove child works from recent works on homepage
     end
 ```
 
+### Skipping Certain File Suffixes for PDF Splitting
+
+By default when a work is configured for splitting PDFs, we will split all PDFs.  However, in some cases you don't want to split based on the file name's suffix.  In that case, configure code as follows:
+
+```ruby
+IiifPrint.config do |config|
+  config.skip_splitting_pdf_files_that_end_with_these_texts = ['.reader.pdf']
+end
+```
+
 ### Derivative Rodeo Configuration
 
 The Derivative Rodeo is used in two ways:

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -30,6 +30,18 @@ module IiifPrint
       @excluded_model_name_solr_field_values = []
     end
 
+    def skip_splitting_pdf_files_that_end_with_these_texts=(values)
+      @skip_splitting_pdf_files_that_end_with_these_texts = Array.wrap(values).map(&:downcase)
+    end
+
+    ##
+    #   @return [Array<String>] the file suffixes (e.g. [".reader.pdf"]) that we will skip.  Per
+    #           the implementation of {.split_for_path_suffix?}, these values are cast to
+    #           downcase.
+    def skip_splitting_pdf_files_that_end_with_these_texts
+      @skip_splitting_pdf_files_that_end_with_these_texts || []
+    end
+
     attr_writer :unique_child_title_generator_function
 
     # The function, with keywords (though maybe you'll want to splat ignore a few), is responsible

--- a/lib/iiif_print/jobs/request_split_pdf_job.rb
+++ b/lib/iiif_print/jobs/request_split_pdf_job.rb
@@ -23,14 +23,7 @@ module IiifPrint
 
         location = Hyrax::WorkingDirectory.find_or_retrieve(file_set.files.first.id, file_set.id)
 
-        # submit a job to split pdf into child works
-        work.iiif_print_config.pdf_splitter_job.perform_later(
-          file_set,
-          [location],
-          user,
-          work.admin_set_id,
-          0 # A no longer used parameter; but we need to preserve the method signature (for now)
-        )
+        IiifPrint.conditionally_submit_split_for(work: work, file_set: file_set, locations: [location], user: user)
       end
       # rubocop:enable Metrics/MethodLength
     end

--- a/spec/iiif_print/configuration_spec.rb
+++ b/spec/iiif_print/configuration_spec.rb
@@ -177,4 +177,17 @@ RSpec.describe IiifPrint::Configuration do
       end.to change(config, :questioning_authority_fields).from(['rights_statement', 'license']).to(['rights_statement', 'license', 'subject'])
     end
   end
+
+  describe '#skip_splitting_pdf_files_that_end_with_these_texts' do
+    subject { config.skip_splitting_pdf_files_that_end_with_these_texts }
+    context 'by default' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'is configurable' do
+      before { config.skip_splitting_pdf_files_that_end_with_these_texts = ['.READER.pdf'] }
+
+      it { is_expected.not_to be_empty }
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, we always split every PDF file.  And for some
situations, we do not want split a PDF (e.g. In Adventist when we have a
work that attaches a reader and archival PDF; we don't need/want to
split the reader PDF, as we're splitting the archival PDF).