### PR TITLE
🐛 Favor `FileUtils.rm_f`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,7 +483,7 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.6.3)
-    json-canonicalization (0.3.2)
+    json-canonicalization (0.3.1)
     json-ld (3.1.10)
       htmlentities (~> 4.3)
       json-canonicalization (~> 0.2)
@@ -1012,6 +1012,7 @@ DEPENDENCIES
   iiif_print!
   jbuilder (~> 2.5)
   jquery-rails
+  json-canonicalization (= 0.3.1)
   newspaper_works_fixtures (~> 0.3, >= 0.3.1)
   puma (~> 3.11)
   rails (~> 5.2.8, >= 5.2.8.1)

--- a/iiif_print.gemspec
+++ b/iiif_print.gemspec
@@ -36,6 +36,7 @@ SUMMARY
   # TODO: We want to remove dependency on this
   spec.add_development_dependency 'newspaper_works_fixtures', '~> 0.3', '>=0.3.1'
   spec.add_development_dependency 'rails-controller-testing', '~> 1'
+  spec.add_development_dependency 'json-canonicalization', '0.3.1'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rspec-activemodel-mocks'
   spec.add_development_dependency 'shoulda-matchers', '~> 3.1'

--- a/lib/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/lib/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -118,7 +118,7 @@ module IiifPrint
 
           begin
             # Clean up the temporary image path.
-            File.rm_f(image_path) if File.exist?(image_path)
+            FileUtils.rm_f(image_path) if File.exist?(image_path)
           rescue
             # If we can't delete, let's move on.  Maybe it was already cleaned-up.
           end


### PR DESCRIPTION
## 🐛 Favor `FileUtils.rm_f`

9c3713c70833c0ebdc6c08ae2fba9b497794243e

`File` does not respond to `.rm_f`; we instead want to use
`FileUtils.rm_f`.

Co-authored-by: Kirk Wang <k3wang@gmail.com>

## 🐛 Address yanked 0.3.2 json-canonicalization

61350ae797afb7c89c7c7a3302a4deabf6ad5593

Related to:

- https://github.com/scientist-softserv/utk-hyku/pull/575
- https://github.com/scientist-softserv/palni-palci/pull/918
