### PR TITLE
🎁 Add listener to set child flag

### DIFF
--- a/app/indexers/concerns/iiif_print/child_indexer.rb
+++ b/app/indexers/concerns/iiif_print/child_indexer.rb
@@ -14,11 +14,11 @@ module IiifPrint
         next unless work_type.respond_to?(:iiif_print_config?)
         next unless work_type.iiif_print_config?
 
-        if work_type < Valkyrie::Resource
-          IiifPrint::PersistenceLayer::ValkyrieAdapter.decorate_with_adapter_logic(work_type: work_type)
-        else
-          IiifPrint::PersistenceLayer::ActiveFedoraAdapter.decorate_with_adapter_logic(work_type: work_type)
-        end
+        indexer = if work_type < Valkyrie::Resource
+                  IiifPrint::PersistenceLayer::ValkyrieAdapter.decorate_with_adapter_logic(work_type: work_type)
+                else
+                  IiifPrint::PersistenceLayer::ActiveFedoraAdapter.decorate_with_adapter_logic(work_type: work_type)
+                end
 
         indexer.prepend(self).class_attribute(:iiif_print_lineage_service, default: IiifPrint::LineageService) unless indexer.respond_to?(:iiif_print_lineage_service)
         work_type::GeneratedResourceSchema.send(:include, IiifPrint::SetChildFlag) if work_type.const_defined?(:GeneratedResourceSchema)

--- a/app/listeners/iiif_print/listener.rb
+++ b/app/listeners/iiif_print/listener.rb
@@ -29,5 +29,20 @@ module IiifPrint
 
       service.conditionally_enqueue(file_set: file_set, work: work, file: file, user: user)
     end
+
+    ##
+    # Responsible for setting the is_child flag on the work when a child work is created.
+    #
+    # @param event [#[]] a hash like construct with :object key
+    def on_object_deposited(event)
+      object = event[:object]
+
+      Hyrax.custom_queries.find_child_works(resource: object).each do |child_work|
+        unless child_work.is_child
+          child_work.is_child = true
+          Hyrax.persister.save(resource: child_work)
+        end
+      end
+    end
   end
 end

--- a/spec/listeners/iiif_print/listener_spec.rb
+++ b/spec/listeners/iiif_print/listener_spec.rb
@@ -30,4 +30,36 @@ RSpec.describe IiifPrint::Listener do
       end
     end
   end
+
+  describe '#on_object_deposited' do
+    class Work < Hyrax::Work
+      include Hyrax::Schema(:child_works_from_pdf_splitting)
+    end
+    subject { described_class.new.on_object_deposited(event) }
+
+    let(:event) { { object: parent_work } }
+    let(:parent_work) do
+      parent_work = Work.new
+      parent_work.title = ['Parent Work']
+      Hyrax.persister.save(resource: parent_work)
+    end
+    let(:child_work) do
+      child_work = Work.new
+      child_work.title = ['Child Work']
+      Hyrax.persister.save(resource: child_work)
+    end
+
+    before do
+      parent_work.member_ids << child_work.id
+      Hyrax.persister.save(resource: parent_work)
+      Hyrax.index_adapter.save(resource: parent_work)
+    end
+
+    it 'sets the is_child flag on the child work' do
+      expect(child_work.is_child).to be nil
+      subject
+      # gets a reloaded version of the child work
+      expect(Hyrax.query_service.find_by(id: child_work.id).is_child).to be true
+    end
+  end
 end


### PR DESCRIPTION
This commit introduces a listener that sets the is_child flag on child works.  It uses the `on_object_deposited` event which is similar to the `after_save` callback.
