### PR TITLE
🧹 Add table_exists? guard clauses to migrations

### DIFF
--- a/db/migrate/20181214181358_create_iiif_print_derivative_attachments.rb
+++ b/db/migrate/20181214181358_create_iiif_print_derivative_attachments.rb
@@ -1,12 +1,14 @@
 class CreateIiifPrintDerivativeAttachments < ActiveRecord::Migration[5.0]
   def change
-    create_table :iiif_print_derivative_attachments do |t|
-      t.string :fileset_id
-      t.string :path
-      t.string :destination_name
+    unless table_exists?(:iiif_print_derivative_attachments)
+      create_table :iiif_print_derivative_attachments do |t|
+        t.string :fileset_id
+        t.string :path
+        t.string :destination_name
 
-      t.timestamps
+        t.timestamps
+      end
+      add_index :iiif_print_derivative_attachments, :fileset_id
     end
-    add_index :iiif_print_derivative_attachments, :fileset_id
   end
 end

--- a/db/migrate/20190107165909_create_iiif_print_ingest_file_relations.rb
+++ b/db/migrate/20190107165909_create_iiif_print_ingest_file_relations.rb
@@ -1,11 +1,13 @@
 class CreateIiifPrintIngestFileRelations < ActiveRecord::Migration[5.0]
   def change
-    create_table :iiif_print_ingest_file_relations do |t|
-      t.string :file_path
-      t.string :derivative_path
+    unless table_exists?(:iiif_print_ingest_file_relations)
+      create_table :iiif_print_ingest_file_relations do |t|
+        t.string :file_path
+        t.string :derivative_path
 
-      t.timestamps
+        t.timestamps
+      end
+      add_index :iiif_print_ingest_file_relations, :file_path
     end
-    add_index :iiif_print_ingest_file_relations, :file_path
   end
 end

--- a/db/migrate/20230109000000_create_iiif_print_pending_relationships.rb
+++ b/db/migrate/20230109000000_create_iiif_print_pending_relationships.rb
@@ -1,11 +1,13 @@
 class CreateIiifPrintPendingRelationships < ActiveRecord::Migration[5.1]
   def change
-    create_table :iiif_print_pending_relationships do |t|
-      t.string :child_title, null: false
-      t.string :parent_id, null: false
-      t.string :child_order, null: false
-      t.timestamps
+    unless table_exists?(:iiif_print_pending_relationships)
+      create_table :iiif_print_pending_relationships do |t|
+        t.string :child_title, null: false
+        t.string :parent_id, null: false
+        t.string :child_order, null: false
+        t.timestamps
+      end
+      add_index :iiif_print_pending_relationships, :parent_id
     end
-    add_index :iiif_print_pending_relationships, :parent_id
   end
 end


### PR DESCRIPTION
Check if table exists before insisting the migration should run.

We had issues when running migrations in a different project because of an error that the table already existed. We fixed it manually but this should fix the source. 

ref: [slack convo](https://assaydepot.slack.com/archives/C0313NKG2DA/p1706031216382859)