### PR TITLE
🐛 Fix boot problem

### DIFF
--- a/config/initializers/simple_schema_loader.rb
+++ b/config/initializers/simple_schema_loader.rb
@@ -1,0 +1,1 @@
+Hyrax::SimpleSchemaLoader.prepend(IiifPrint::SimpleSchemaLoaderDecorator)

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -22,6 +22,9 @@ require "iiif_print/split_pdfs/base_splitter"
 require "iiif_print/split_pdfs/child_work_creation_from_pdf_service"
 require "iiif_print/split_pdfs/derivative_rodeo_splitter"
 require "iiif_print/split_pdfs/destroy_pdf_child_works_service"
+require "iiif_print/persistence_layer"
+require "iiif_print/persistence_layer/active_fedora_adapter"
+require "iiif_print/persistence_layer/valkyrie_adapter"
 
 # rubocop:disable Metrics/ModuleLength
 module IiifPrint

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -51,10 +51,6 @@ module IiifPrint
       Hyrax::IiifManifestPresenter.prepend(IiifPrint::IiifManifestPresenterBehavior)
       Hyrax::IiifManifestPresenter::Factory.prepend(IiifPrint::IiifManifestPresenterFactoryBehavior)
       Hyrax::ManifestBuilderService.prepend(IiifPrint::ManifestBuilderServiceBehavior)
-
-      # Hyrax::SimpleSchemaLoader was introduced in Hyrax 3.0; as this gem supports Hyrax 2.9.6 we need to be cautious
-      'Hyrax::SimpleSchemaLoader'.safe_constantize&.prepend(IiifPrint::SimpleSchemaLoaderDecorator)
-
       Hyrax::Renderers::FacetedAttributeRenderer.prepend(Hyrax::Renderers::FacetedAttributeRendererDecorator)
       Hyrax::WorksControllerBehavior.prepend(IiifPrint::WorksControllerBehaviorDecorator)
 

--- a/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
+++ b/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
@@ -21,9 +21,6 @@ module IiifPrint
       # @param work_type [Class<Valkyrie::Resource>]
       # @return the indexer for the given :work_type
       def self.decorate_with_adapter_logic(work_type:)
-        # Originally prepended in the engine.rb but this placement loads it sooner.
-        Hyrax::SimpleSchemaLoader.prepend(IiifPrint::SimpleSchemaLoaderDecorator)
-
         work_type.send(:include, Hyrax::Schema(:child_works_from_pdf_splitting)) unless work_type.included_modules.include?(Hyrax::Schema(:child_works_from_pdf_splitting))
         # TODO: Use `Hyrax::ValkyrieIndexer.indexer_class_for` once changes are merged.
         indexer = "#{work_type}Indexer".constantize

--- a/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
+++ b/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
@@ -21,6 +21,9 @@ module IiifPrint
       # @param work_type [Class<Valkyrie::Resource>]
       # @return the indexer for the given :work_type
       def self.decorate_with_adapter_logic(work_type:)
+        # Originally prepended in the engine.rb but this placement loads it sooner.
+        Hyrax::SimpleSchemaLoader.prepend(IiifPrint::SimpleSchemaLoaderDecorator)
+
         work_type.send(:include, Hyrax::Schema(:child_works_from_pdf_splitting)) unless work_type.included_modules.include?(Hyrax::Schema(:child_works_from_pdf_splitting))
         # TODO: Use `Hyrax::ValkyrieIndexer.indexer_class_for` once changes are merged.
         indexer = "#{work_type}Indexer".constantize


### PR DESCRIPTION
This fix will add a few more requires to the engine.rb file and also move the simple schema loader decorator to the valkyrie_adapter because when a valkyrie application is booting up, the schema path needs to be in place before loading the yaml.
