### PR TITLE
🧹 Correct transactions names and set condition

### DIFF
--- a/app/transactions/hyrax/transactions/iiif_print_container_decorator.rb
+++ b/app/transactions/hyrax/transactions/iiif_print_container_decorator.rb
@@ -28,29 +28,31 @@ module Hyrax
         end
       end
 
-      if ENV['HYKU_IIIF_PRINT']
-        namespace 'change_set' do |ops|
-          ops.register 'update_work' do
-            steps = Hyrax::Transactions::WorkUpdate::DEFAULT_STEPS.dup
+      namespace 'change_set' do |ops|
+        ops.register 'update_work' do
+          steps = Hyrax::Transactions::WorkUpdate::DEFAULT_STEPS.dup
+          # NOTE: applications that don't want the file splitting of IIIF Print will want to remove
+          # this step from their transactions.
+          steps.insert(steps.index('work_resource.update_work_members') + 1, 'work_resource.set_child_flag')
+          Hyrax::Transactions::WorkUpdate.new(steps: steps)
+        end
+      end
+
+      if defined?(Bulkrax::Transactions::Container)
+        namespace 'work_resource' do |ops|
+          ops.register Bulkrax::Transactions::Container::UPDATE_WITH_BULK_BEHAVIOR do
+            steps = Bulkrax::Transactions::Container::UPDATE_WITH_BULK_BEHAVIOR_STEPS.dup
+            # NOTE: applications that don't want the file splitting of IIIF Print will want to remove
+            # this step from their transactions.
             steps.insert(steps.index('work_resource.update_work_members') + 1, 'work_resource.set_child_flag')
             Hyrax::Transactions::WorkUpdate.new(steps: steps)
           end
         end
+      end
 
-        if defined?(Bulkrax::Transactions::Container)
-          namespace 'work_resource' do |ops|
-            ops.register Bulkrax::Transactions::Container::UPDATE_WITH_BULK_BEHAVIOR do
-              steps = Bulkrax::Transactions::Container::UPDATE_WITH_BULK_BEHAVIOR_STEPS.dup
-              steps.insert(steps.index('work_resource.update_work_members') + 1, 'work_resource.set_child_flag')
-              Hyrax::Transactions::WorkUpdate.new(steps: steps)
-            end
-          end
-        end
-
-        namespace 'work_resource' do |ops|
-          ops.register 'set_child_flag' do
-            Steps::SetChildFlag.new
-          end
+      namespace 'work_resource' do |ops|
+        ops.register 'set_child_flag' do
+          Steps::SetChildFlag.new
         end
       end
     end

--- a/app/transactions/hyrax/transactions/iiif_print_container_decorator.rb
+++ b/app/transactions/hyrax/transactions/iiif_print_container_decorator.rb
@@ -28,27 +28,29 @@ module Hyrax
         end
       end
 
-      namespace 'change_set' do |ops|
-        ops.register 'update_work' do
-          steps = Hyrax::Transactions::WorkUpdate::DEFAULT_STEPS.dup
-          steps.insert(steps.index('work_resource.update_work_members') + 1, 'work_resource.set_child_flag')
-          Hyrax::Transactions::WorkUpdate.new(steps: steps)
-        end
-      end
-
-      if defined?(Bulkrax::Container)
-        namespace 'work_resource' do |ops|
-          ops.register Bulkrax::Container::UPDATE_WITH_BULK_BEHAVIOR do
-            steps = Bulkrax::Container::UPDATE_WITH_BULK_BEHAVIOR_STEPS.dup
+      if ENV['HYKU_IIIF_PRINT']
+        namespace 'change_set' do |ops|
+          ops.register 'update_work' do
+            steps = Hyrax::Transactions::WorkUpdate::DEFAULT_STEPS.dup
             steps.insert(steps.index('work_resource.update_work_members') + 1, 'work_resource.set_child_flag')
             Hyrax::Transactions::WorkUpdate.new(steps: steps)
           end
         end
-      end
 
-      namespace 'work_resource' do |ops|
-        ops.register 'set_child_flag' do
-          Steps::SetChildFlag.new
+        if defined?(Bulkrax::Transactions::Container)
+          namespace 'work_resource' do |ops|
+            ops.register Bulkrax::Transactions::Container::UPDATE_WITH_BULK_BEHAVIOR do
+              steps = Bulkrax::Transactions::Container::UPDATE_WITH_BULK_BEHAVIOR_STEPS.dup
+              steps.insert(steps.index('work_resource.update_work_members') + 1, 'work_resource.set_child_flag')
+              Hyrax::Transactions::WorkUpdate.new(steps: steps)
+            end
+          end
+        end
+
+        namespace 'work_resource' do |ops|
+          ops.register 'set_child_flag' do
+            Steps::SetChildFlag.new
+          end
         end
       end
     end

--- a/app/transactions/hyrax/transactions/steps/set_child_flag.rb
+++ b/app/transactions/hyrax/transactions/steps/set_child_flag.rb
@@ -6,12 +6,18 @@ module Hyrax
       class SetChildFlag
         include Dry::Monads[:result]
 
+        # @see IiifPrint.model_configuration
         def call(resource)
           return Failure(:resource_not_persisted) unless resource.persisted?
 
           user = ::User.find_by_user_key(resource.depositor)
 
           Hyrax.custom_queries.find_child_works(resource: resource).each do |child_work|
+            # not all child works might have the is_child property that we define when we configure
+            # the a model for iiif_print.  see IiifPrint.model_configuration
+            #
+            # Put another the existence of the is_child property is optional.
+            next unless child_work.respond_to?(:is_child)
             next if child_work.is_child
             child_work.is_child = true
             Hyrax.persister.save(resource: child_work)


### PR DESCRIPTION
This commit will fix names since it changed somewhere along the way. The set child flag was being called when IIIF Print was not being used which resulted in an error.  This commit will set the condition to only call if the HYKU_IIIF_PRINT env var is true.

otherwise an error like this occurs: 
![Screenshot 2024-02-01 at 14-46-40 Action Controller Exception caught](https://github.com/scientist-softserv/iiif_print/assets/10081604/5078e2a9-d84a-482d-9968-6fb339f6d68c)

