### PR TITLE
🐛 Fix `ActiveFedora::SolrQueryBuilder`

### DIFF
--- a/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
+++ b/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
@@ -57,7 +57,7 @@ module IiifPrint
         if defined?(Hyrax::SolrQueryBuilderService)
           Hyrax::SolrQueryBuilderService.construct_query(*args)
         else
-          ActiveFedora::SolrQueryBuilderService.construct_query(*args)
+          ActiveFedora::SolrQueryBuilder.construct_query(*args)
         end
       end
 


### PR DESCRIPTION
Looks like it was just misnamed.
