### PR TITLE
🧹 Make valkyrie file sets show in uv

### DIFF
--- a/app/services/iiif_print/manifest_builder_service_behavior.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior.rb
@@ -144,7 +144,9 @@ module IiifPrint
         query = "id:(#{paged_ids.join(' OR ')})"
         results += IiifPrint.solr_query(
           query,
-          { fq: "-has_model_ssim:FileSet", rows: paged_ids.size, method: :post }
+          fq: "-has_model_ssim:FileSet",
+          rows: paged_ids.size,
+          method: :post
         )
       end
       results

--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -5,7 +5,7 @@ module IiifPrint
 
     attr_writer :persistence_adapter
     def persistence_adapter
-      @persistent_adapter || default_persistence_adapter
+      @persistence_adapter || default_persistence_adapter
     end
 
     def default_persistence_adapter

--- a/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
+++ b/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
@@ -67,11 +67,11 @@ module IiifPrint
         end
       end
 
-      def self.solr_query(*args)
+      def self.solr_query(query, **args)
         if defined?(Hyrax::SolrService)
-          Hyrax::SolrService.query(*args)
+          Hyrax::SolrService.query(query, **args)
         else
-          ActiveFedora::SolrService.query(*args)
+          ActiveFedora::SolrService.query(query, **args)
         end
       end
 

--- a/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
+++ b/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
@@ -35,7 +35,7 @@ module IiifPrint
       # @return [#work?, Hydra::PCDM::Work]
       # @return [NilClass] when no parent is found.
       def self.parent_for(file_set)
-        Hyrax.index_adapter.find_parents(resource: file_set).first
+        Hyrax.query_service.find_parents(resource: file_set).first
       end
 
       ##
@@ -45,9 +45,9 @@ module IiifPrint
       # @return [#work?, Hydra::PCDM::Work]
       # @return [NilClass] when no grand parent is found.
       def self.grandparent_for(file_set)
-        parent = Hyrax.index_adapter.find_parents(resource: file_set).first
+        parent = Hyrax.query_service.find_parents(resource: file_set).first
         return nil unless parent
-        Hyrax.index_adapter.find_parents(resource: parent).first
+        Hyrax.query_service.find_parents(resource: parent).first
       end
 
       def self.solr_construct_query(*args)
@@ -60,8 +60,8 @@ module IiifPrint
         raise NotImplementedError
       end
 
-      def self.solr_query(*args)
-        Hyrax::SolrService.query(*args)
+      def self.solr_query(query, **args)
+        Hyrax::SolrService.query(query, **args)
       end
 
       def self.solr_name(field_name)


### PR DESCRIPTION
This commit corrects a typo in the configuration file and corrects the `.find_parents` method to be called on `Hyrax.query_service` instead. We also correct the method signature for `ValkyrieAdapter.solr_query` so it works with Ruby 3.0.0+ as well as its call.
