### PR TITLE
🎁 Favor ActiveFedora::SolrService for Fedora adapter

### DIFF
--- a/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
+++ b/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
@@ -68,10 +68,10 @@ module IiifPrint
       end
 
       def self.solr_query(query, **args)
-        if defined?(Hyrax::SolrService)
-          Hyrax::SolrService.query(query, **args)
-        else
+        if defined?(ActiveFedora::SolrService)
           ActiveFedora::SolrService.query(query, **args)
+        else
+          Hyrax::SolrService.query(query, **args)
         end
       end
 


### PR DESCRIPTION
This relates to the fact that `Hyrax::SolrService` does not behave the same way (for earlier versions of Hyrax).

Related to:

- https://github.com/samvera/hyrax/pull/6677
