### PR TITLE
🎁 Implement delete work for valyrie adapter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-guests (0.8.1)
+    devise-guests (0.8.2)
       devise
     diff-lcs (1.5.0)
     disposable (0.4.7)
@@ -913,7 +913,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.9)
+    sqlite3 (1.7.2)
       mini_portile2 (~> 2.8.0)
     ssrf_filter (1.0.8)
     sxp (1.2.4)

--- a/app/transactions/hyrax/transactions/steps/conditionally_destroy_children_from_split.rb
+++ b/app/transactions/hyrax/transactions/steps/conditionally_destroy_children_from_split.rb
@@ -10,7 +10,7 @@ module Hyrax
 
         ##
         # @param resource [Hyrax::FileSet]
-        def call(resource)
+        def call(resource, user: nil)
           return Failure(:resource_not_persisted) unless resource.persisted?
 
           parent = IiifPrint.persistence_adapter.parent_for(resource)
@@ -20,10 +20,11 @@ module Hyrax
           # to destroy.
           IiifPrint::SplitPdfs::DestroyPdfChildWorksService.conditionally_destroy_spawned_children_of(
             file_set: resource,
-            work: parent
+            work: parent,
+            user: user
           )
 
-          Success(true)
+          Success(resource)
         end
       end
     end

--- a/app/transactions/hyrax/transactions/steps/delete_all_file_sets_decorator.rb
+++ b/app/transactions/hyrax/transactions/steps/delete_all_file_sets_decorator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax 5.0.0rc2 to add file_set.iiif_print_conditionally_destroy_spawned_children with user args
+
+module Hyrax
+  module Transactions
+    module Steps
+      module DeleteAllFileSetsDecorator
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Valkyrie::Resource] resource
+        # @param [::User] the user resposible for the delete action
+        #
+        # @return [Dry::Monads::Result]
+        def call(resource, user: nil)
+          return Failure(:resource_not_persisted) unless resource.persisted?
+
+          @query_service.custom_queries.find_child_file_sets(resource: resource).each do |file_set|
+            return Failure[:failed_to_delete_file_set, file_set] unless
+              Hyrax::Transactions::Container['file_set.destroy']
+              .with_step_args('file_set.remove_from_work' => { user: user },
+                              'file_set.delete' => { user: user },
+                              'file_set.iiif_print_conditionally_destroy_spawned_children' => { user: user })
+              .call(file_set).success?
+          rescue ::Ldp::Gone
+            nil
+          end
+
+          Success(resource)
+        end
+      end
+    end
+  end
+end

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -60,6 +60,7 @@ module IiifPrint
       :object_in_works,
       :object_ordered_works,
       :parent_for,
+      :pdf?,
       :solr_construct_query,
       :solr_name,
       :solr_query,

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -53,7 +53,7 @@ module IiifPrint
       Hyrax::ManifestBuilderService.prepend(IiifPrint::ManifestBuilderServiceBehavior)
       Hyrax::Renderers::FacetedAttributeRenderer.prepend(Hyrax::Renderers::FacetedAttributeRendererDecorator)
       Hyrax::WorksControllerBehavior.prepend(IiifPrint::WorksControllerBehaviorDecorator)
-
+      "Hyrax::Transactions::Steps::DeleteAllFileSets".safe_constantize&.prepend(Hyrax::Transactions::Steps::DeleteAllFileSetsDecorator)
       # Hyku::WorksControllerBehavior was introduced in Hyku v6.0.0+.  Yes we don't depend on Hyku,
       # but this allows us to do minimal Hyku antics with IiifPrint.
       'Hyku::WorksControllerBehavior'.safe_constantize&.prepend(IiifPrint::WorksControllerBehaviorDecorator)

--- a/lib/iiif_print/persistence_layer.rb
+++ b/lib/iiif_print/persistence_layer.rb
@@ -74,6 +74,10 @@ module IiifPrint
       def self.solr_name(*args)
         raise NotImplementedError, "#{self}.{__method__}"
       end
+
+      def self.pdf?(_file_set)
+        raise NotImplementedError, "#{self}.{__method__}"
+      end
     end
   end
 end

--- a/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
+++ b/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
@@ -87,7 +87,7 @@ module IiifPrint
       # @param file_set [Object]
       # @param work [Object]
       # @param model [Class] The class name for which we'll split children.
-      def self.destroy_children_split_from(file_set:, work:, model:)
+      def self.destroy_children_split_from(file_set:, work:, model:, **_args)
         # look first for children by the file set id they were split from
         children = model.where(split_from_pdf_id: file_set.id)
         if children.blank?
@@ -99,6 +99,10 @@ module IiifPrint
           rcd.destroy(eradicate: true)
         end
         true
+      end
+
+      def self.pdf?(file_set)
+        file_set.class.pdf_mime_types.include?(file_set.mime_type)
       end
     end
   end

--- a/lib/iiif_print/split_pdfs/destroy_pdf_child_works_service.rb
+++ b/lib/iiif_print/split_pdfs/destroy_pdf_child_works_service.rb
@@ -7,15 +7,15 @@ module IiifPrint
       ## @api public
       # @param file_set [FileSet] What is the containing file set for the provided file.
       # @param work [Hydra::PCDM::Work] Parent of the fileset being deleted
-      def self.conditionally_destroy_spawned_children_of(file_set:, work:)
+      def self.conditionally_destroy_spawned_children_of(file_set:, work:, user: nil)
         child_model = work.try(:iiif_print_config)&.pdf_split_child_model
         return unless child_model
-        return unless file_set.class.pdf_mime_types.include?(file_set.mime_type)
+        return unless IiifPrint.pdf?(file_set)
 
         # NOTE: The IiifPrint::PendingRelationship is an ActiveRecord object; hence we don't need to
         # leverage an adapter.
         IiifPrint::PendingRelationship.where(parent_id: work.id, file_id: file_set.id).find_each(&:destroy)
-        IiifPrint.destroy_children_split_from(file_set: file_set, work: work, model: child_model)
+        IiifPrint.destroy_children_split_from(file_set: file_set, work: work, model: child_model, user: user)
       end
     end
   end

--- a/spec/iiif_print/split_pdfs/destroy_pdf_child_works_service_spec.rb
+++ b/spec/iiif_print/split_pdfs/destroy_pdf_child_works_service_spec.rb
@@ -3,10 +3,12 @@
 require 'spec_helper'
 
 RSpec.describe IiifPrint::SplitPdfs::DestroyPdfChildWorksService do
-  let(:subject) { described_class.conditionally_destroy_spawned_children_of(file_set: fileset, work: work) }
+  let(:subject) { described_class.conditionally_destroy_spawned_children_of(file_set: fileset, work: work, user: user) }
 
+  let(:user) { double('User') }
   let(:work) { WorkWithIiifPrintConfig.new(title: ['required title'], id: '123') }
   let(:fileset) { FileSet.new.tap { |fs| fs.save!(validate: false) } }
+  let(:solr_document) { SolrDocument.find(fileset.id) }
   let(:child_work) { WorkWithIiifPrintConfig.new(title: ["Child of #{work.id} file.pdf page 01"], id: '456', is_child: true) }
   let(:pending_rel1) do
     IiifPrint::PendingRelationship.new(
@@ -35,6 +37,8 @@ RSpec.describe IiifPrint::SplitPdfs::DestroyPdfChildWorksService do
     allow(fileset).to receive(:parent).and_return(work)
     allow(fileset).to receive(:label).and_return('file.pdf')
     allow(fileset).to receive(:mime_type).and_return('application/pdf')
+    allow(solr_document).to receive(:pdf?).and_return(true)
+    allow(SolrDocument).to receive(:find).with(fileset.id).and_return(solr_document)
   end
 
   describe 'class' do

--- a/spec/transactions/hyrax/transactions/steps/conditionally_destroy_children_from_split_spec.rb
+++ b/spec/transactions/hyrax/transactions/steps/conditionally_destroy_children_from_split_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::Transactions::Steps::ConditionallyDestroyChildrenFromSplit
         let(:parent) { double(Valkyrie::Resource) }
         it do
           expect(IiifPrint::SplitPdfs::DestroyPdfChildWorksService).to receive(:conditionally_destroy_spawned_children_of)
-            .with(file_set: file_set, work: parent)
+            .with(file_set: file_set, work: parent, user: nil)
           is_expected.to be_success
         end
       end


### PR DESCRIPTION
This commit will add an override for the `DeleteAllFileSets` step so we can insert the `iiif_print_conditionally_destroy_spawned_children` with args, we want to pass in the user so we can publish it to any relevant listeners.  We also implement the valkyrie way of deleting split child works in the `destroy_children_split_from` method.
