### PR TITLE
🐛 Cast ID to String to Account for Valkyrie::ID

### DIFF
--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -44,11 +44,14 @@ module IiifPrint
     end
 
     attr_writer :ancestory_identifier_function
-    # The function, with arity 1, that receives a work and returns it's identifier for the purposes
-    # of object ancestry.
+    # The function, with arity 1, that receives a work and returns it's identifier (as a string) for
+    # the purposes of object ancestry.
+    #
     # @return [Proc]
     def ancestory_identifier_function
-      @ancestory_identifier_function ||= ->(work) { work.id }
+      # If the work.id is nil, keep it nil.  Otherwise cast that id to a string; to deal with the
+      # `Valkyrie::ID`.
+      @ancestory_identifier_function ||= ->(work) { work.id&.to_s }
     end
 
     attr_writer :excluded_model_name_solr_field_values

--- a/lib/iiif_print/lineage_service.rb
+++ b/lib/iiif_print/lineage_service.rb
@@ -16,6 +16,9 @@ module IiifPrint
     #
     # @param object [#in_works] An object that responds to #in_works
     # @return [Array<String>]
+    #
+    # @note For those implementing their own lineage service, verify that you are not returning
+    #       an array of
     def self.ancestor_ids_for(object)
       ancestor_ids ||= []
       # Yes, we're fetching the works, then compressing those into identifiers.  Because in the case
@@ -24,7 +27,10 @@ module IiifPrint
         ancestor_ids << ancestry_identifier_for(work)
         ancestor_ids += ancestor_ids_for(work) if work.respond_to?(:is_child) && work.is_child
       end
-      ancestor_ids.flatten.compact.uniq
+      # We must convert these to strings as Valkyrie's identifiers will be cast to hashes when we
+      # attempt to write the SolrDocument.  Also, per documentation we return an Array of strings, not
+      # an Array that might include Valkyrie::ID objects.
+      ancestor_ids.flatten.compact.uniq.map(&:to_s)
     end
 
     ##
@@ -56,7 +62,9 @@ module IiifPrint
       IiifPrint.object_ordered_works(object)&.each do |child|
         file_set_ids += descendent_member_ids_for(child)
       end
-      file_set_ids.flatten.uniq.compact
+      # We must convert these to strings as Valkyrie's identifiers will be cast to hashes when we
+      # attempt to write the SolrDocument.
+      file_set_ids.flatten.uniq.compact.map(&:to_s)
     end
     class << self
       alias descendent_file_set_ids_for descendent_member_ids_for


### PR DESCRIPTION
Prior to this, casting a Valkyrie::ID to a SolrDocument value would create a hash and produce the following error:

```
RSolr::Error::Http:
RSolr::Error::Http - 400 Bad Request
Error: Unable to index docs with children: the schema must include
definitions for both a uniqueKey field and the '_root_' field, using the
exact same fieldType
```

See:

http://playbook-staging.notch8.com/en/samvera/hyku/troubleshooting/unable-to-index-docs-with-children