### PR TITLE
use -ping for more efficient IM identify

### DIFF
--- a/lib/iiif_print/image_tool.rb
+++ b/lib/iiif_print/image_tool.rb
@@ -74,7 +74,7 @@ module IiifPrint
 
     # @return [Array<String>] lines of output from imagemagick `identify`
     def im_identify
-      cmd = "identify -format 'Geometry: %G\nDepth: %[bit-depth]\nColorspace: %[colorspace]\nAlpha: %A\nMIME type: %m\n' #{path}"
+      cmd = "identify -ping -format 'Geometry: %G\nDepth: %[bit-depth]\nColorspace: %[colorspace]\nAlpha: %A\nMIME type: %m\n' #{path}"
       `#{cmd}`.lines
     end
 


### PR DESCRIPTION
identify with -format will get killed when attempted with higher resolution images. -ping will extract the image metadata with much less resource use.

# Story

https://assaydepot.slack.com/archives/C030UPFBT2S/p1708949667556879

# Expected Behavior Before Changes

Hi-res images created from big page PDFs e.g. https://sciencemuseumgroup.iro.bl.uk/concern/exhibition_items/02c65fab-9458-41c3-9120-435348d64681 will fail to create derivatives as identify command does not complete

# Expected Behavior After Changes

Big PDFs and their Jpegs will get their derivatives again