### PR TITLE
🐛 Disable rubocop for necessary parameter name

### DIFF
--- a/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
+++ b/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
@@ -68,7 +68,9 @@ module IiifPrint
         Hyrax.config.index_field_mapper.solr_name(field_name.to_s)
       end
 
-      def self.destroy_children_split_from(file_set:, _work:, model:, user:)
+      # rubocop:disable Lint/UnusedMethodArgument
+      def self.destroy_children_split_from(file_set:, work:, model:, user:)
+        # rubocop:enable Lint/UnusedMethodArgument
         # look for child records by the file set id they were split from
         Hyrax.query_service.find_inverse_references_by(resource: file_set, property: :split_from_pdf_id, model: model).each do |child|
           Hyrax.persister.delete(resource: child)


### PR DESCRIPTION
# Story

Refs https://github.com/scientist-softserv/hykuup_knapsack/issues/187

# Expected Behavior Before Changes

Deleting a work with a PDF file failed with a iiif_print error.

# Expected Behavior After Changes

Deleting a work succeeds.