### PR TITLE
Fixes PDF splitting for Valkyrie resources

### DIFF
--- a/app/indexers/concerns/iiif_print/child_work_indexer.rb
+++ b/app/indexers/concerns/iiif_print/child_work_indexer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module IiifPrint
+  module ChildWorkIndexer
+    def to_solr
+      super.tap do |index_document|
+        index_solr_doc(index_document)
+      end
+    end
+
+    def generate_solr_document
+      super.tap do |solr_doc|
+        index_solr_doc(solr_doc)
+      end
+    end
+
+    private
+
+    def index_solr_doc(solr_doc)
+      object ||= @object || resource
+
+      solr_doc['is_child_bsi'] ||= object.is_child
+      solr_doc['split_from_pdf_id_ssi'] ||= object.split_from_pdf_id
+      solr_doc['is_page_of_ssim'] = iiif_print_lineage_service.ancestor_ids_for(object)
+      solr_doc['member_ids_ssim'] = iiif_print_lineage_service.descendent_member_ids_for(object)
+    end
+  end
+end

--- a/app/indexers/concerns/iiif_print/file_set_indexer.rb
+++ b/app/indexers/concerns/iiif_print/file_set_indexer.rb
@@ -57,21 +57,10 @@ module IiifPrint
     end
     private_class_method :decorate_index_document_method
 
-    def to_solr
-      super.tap do |solr_doc|
-        object ||= @object || resource
-        # only UV viewable images should have is_page_of, it is only used for iiif search
-        solr_doc['is_page_of_ssim'] = iiif_print_lineage_service.ancestor_ids_for(object) if image?(object)
-        # index for full text search
-        solr_doc['all_text_tsimv'] = solr_doc['all_text_timv'] = all_text(object)
-        solr_doc['digest_ssim'] = digest_from_content(object)
-      end
-    end
-
     private
 
     def image?(object)
-      mime_type = object.try(:mime_type) || object.file_metadata.mime_type
+      mime_type = object.try(:mime_type) || object.original_file.mime_type
       mime_type&.match(/image/)
     end
 

--- a/app/indexers/concerns/iiif_print/file_set_indexer.rb
+++ b/app/indexers/concerns/iiif_print/file_set_indexer.rb
@@ -35,7 +35,7 @@ module IiifPrint
     end
 
     def image?(object)
-      mime_type = object.try(:mime_type) || object.original_file.mime_type
+      mime_type = object.try(:mime_type) || object.original_file&.mime_type
       mime_type&.match(/image/)
     end
 

--- a/app/jobs/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/app/jobs/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -71,7 +71,7 @@ module IiifPrint
                 "pdf_file_set #{pdf_file_set.inspect}"
         end
 
-        @split_from_pdf_id = pdf_file_set&.id&.try(:id) || pdf_file_set&.id
+        @split_from_pdf_id = pdf_file_set&.id.to_s
         prepare_import_data(original_pdf_path, image_files, user)
 
         # submit the job to create all the child works for one PDF

--- a/app/jobs/iiif_print/jobs/child_works_from_pdf_job.rb
+++ b/app/jobs/iiif_print/jobs/child_works_from_pdf_job.rb
@@ -12,7 +12,9 @@ module IiifPrint
       # @param user: [User]
       # @param admin_set_id: [<String>]
       # rubocop:disable Metrics/MethodLength
-      def perform(candidate_for_parency, pdf_paths, user, admin_set_id, *)
+      def perform(id, pdf_paths, user, admin_set_id, *)
+        candidate_for_parency = Hyrax.query_service.find_by(id: id)
+
         ##
         # We know that we have cases where parent_work is nil, this will definitely raise an
         # exception; which is fine because we were going to do it later anyway.
@@ -31,7 +33,7 @@ module IiifPrint
         # However, there seem to be cases where we still don't have the file when we get here, so to be sure, we
         # re-do the same command that was previously used to prepare the file path. If the file is already here, it
         # simply returns the path, but if not it will copy the file there, giving us one more chance to have what we need.
-        pdf_paths = [Hyrax::WorkingDirectory.find_or_retrieve(pdf_file_set.files.first.id, pdf_file_set.id, pdf_paths.first)] if pdf_file_set
+        pdf_paths = [Hyrax::WorkingDirectory.find_or_retrieve(pdf_file_set.original_file.id, pdf_file_set.id, pdf_paths.first)] if pdf_file_set
         # handle each input pdf (when input is a file set, we will only have one).
         pdf_paths.each do |original_pdf_path|
           split_pdf(original_pdf_path, user, child_model, pdf_file_set)
@@ -44,7 +46,7 @@ module IiifPrint
         # @param child_model: [<String>] child model
         IiifPrint::Jobs::CreateRelationshipsJob.set(wait: 10.minutes).perform_later(
           user: user,
-          parent_id: @parent_work.id,
+          parent_id: @parent_work.id.to_s,
           parent_model: @parent_work.class.to_s,
           child_model: child_model.to_s
         )
@@ -58,17 +60,18 @@ module IiifPrint
       # rubocop:disable Metrics/ParameterLists
       # rubocop:disable Metrics/MethodLength
       def split_pdf(original_pdf_path, user, child_model, pdf_file_set)
-        image_files = @parent_work.iiif_print_config.pdf_splitter_service.call(original_pdf_path, file_set: pdf_file_set)
+        user = User.find_by_user_key(user) unless user.is_a?(User)
+        image_files = @parent_work.iiif_print_config.pdf_splitter_service.call(original_pdf_path)
 
         # give as much info as possible if we don't have image files to work with.
         if image_files.blank?
-          raise "#{@parent_work.class} (ID=#{@parent_work.id} " /
-                "to_param:#{@parent_work.to_param}) " /
-                "original_pdf_path #{original_pdf_path.inspect} " /
+          raise "#{@parent_work.class} (ID=#{@parent_work.id} " \
+                "to_param:#{@parent_work.to_param}) " \
+                "original_pdf_path #{original_pdf_path.inspect} " \
                 "pdf_file_set #{pdf_file_set.inspect}"
         end
 
-        @split_from_pdf_id = pdf_file_set&.id
+        @split_from_pdf_id = pdf_file_set&.id&.try(:id) || pdf_file_set&.id
         prepare_import_data(original_pdf_path, image_files, user)
 
         # submit the job to create all the child works for one PDF
@@ -135,7 +138,7 @@ module IiifPrint
       def create_uploaded_file(user, path)
         # TODO: Could we create a remote path?
         uf = Hyrax::UploadedFile.new
-        uf.user_id = user.id
+        uf.user_id = user.try(:id) || user
         uf.file = CarrierWave::SanitizedFile.new(path)
         uf.save!
         uf.id

--- a/app/jobs/iiif_print/jobs/create_relationships_job.rb
+++ b/app/jobs/iiif_print/jobs/create_relationships_job.rb
@@ -151,6 +151,8 @@ module IiifPrint
           parent_record.member_ids << child_record.id
           Hyrax.persister.save(resource: parent_record)
           Hyrax.index_adapter.save(resource: parent_record)
+
+          Hyrax.publisher.publish('object.membership.updated', object: parent_record, user: parent_record.depositor)
         end
       end
     end

--- a/app/listeners/iiif_print/listener.rb
+++ b/app/listeners/iiif_print/listener.rb
@@ -27,21 +27,5 @@ module IiifPrint
       file = file_set.original_file
       service.conditionally_enqueue(file_set: file_set, work: work, file: file, user: user)
     end
-
-    ##
-    # Responsible for setting the is_child flag on the work when a child work is created.
-    #
-    # @param event [#[]] a hash like construct with :object key
-    def on_object_membership_updated(event)
-      object = event[:object]
-      return unless object.respond_to?(:iiif_print_config?) && object.iiif_print_config?
-
-      Hyrax.custom_queries.find_child_works(resource: object).each do |child_work|
-        next if child_work.is_child
-        child_work.is_child = true
-        Hyrax.persister.save(resource: child_work)
-        Hyrax.index_adapter.save(resource: child_work)
-      end
-    end
   end
 end

--- a/app/listeners/iiif_print/listener.rb
+++ b/app/listeners/iiif_print/listener.rb
@@ -11,22 +11,20 @@ module IiifPrint
     # @param service [#conditionally_enqueue]
     #
     # @see Hyrax::WorkUploadsHandler
-    def on_file_set_attached(event, service: IiifPrint::SplitPdfs::ChildWorkCreationFromPdfService)
-      user = event[:user]
+    def on_file_characterized(event, service: IiifPrint::SplitPdfs::ChildWorkCreationFromPdfService)
       file_set = event[:file_set]
-
       return false unless file_set
       return false unless file_set.file_set?
+      return false unless file_set.original_file.pdf?
 
       work = IiifPrint.parent_for(file_set)
-
       # A short-circuit to avoid fetching the underlying file.
       return false unless work
 
+      user = work.depositor
       # TODO: Verify that this is the correct thing to be sending off for conditional enquing.  That
       # will require a more involved integration test.
       file = file_set.original_file
-
       service.conditionally_enqueue(file_set: file_set, work: work, file: file, user: user)
     end
 

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -277,11 +277,15 @@ module IiifPrint
     locations = locations.select { |location| split_for_path_suffix?(location, skip_these_endings: skip_these_endings) }
     return :no_pdfs_for_splitting if locations.empty?
 
+    # Hyrax::FileSet ids are Valkyrie::ID's which can't be passed, so we call id on that and get the string id
+    file_set_id = file_set.id.try(:id) || file_set.id
+    work_admin_set_id = work.admin_set_id.try(:id) || work.admin_set_id
+
     work.try(:iiif_print_config)&.pdf_splitter_job&.perform_later(
-      file_set,
+      file_set_id,
       locations,
       user,
-      work.admin_set_id,
+      work_admin_set_id,
       0 # A no longer used parameter; but we need to preserve the method signature (for now)
     )
   end

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -136,6 +136,14 @@ module IiifPrint
                     raise "Unable to mix '.model_configuration' into #{work_type}"
                   end
 
+        form = if defined?(Valkyrie::Resource) && work_type < Valkyrie::Resource
+                  IiifPrint::PersistenceLayer::ValkyrieAdapter.decorate_form_with_adapter_logic(work_type: work_type)
+                elsif work_type < ActiveFedora::Base
+                  IiifPrint::PersistenceLayer::ActiveFedoraAdapter.decorate_form_with_adapter_logic(work_type: work_type)
+                else
+                  raise "Unable to mix '.model_configuration' into #{work_type}"
+                end
+
         # Deriving lineage of objects is a potentially complicated thing.  We provide a default
         # service but each work_type's indexer can be configured by amending it's
         # {.iiif_print_lineage_service}.

--- a/lib/iiif_print/data/fileset_helper.rb
+++ b/lib/iiif_print/data/fileset_helper.rb
@@ -15,9 +15,9 @@ module IiifPrint
         #   get the fileset from that id
         return FileSet.find(@work) if @work.is_a?(String)
         # if "work" context is a FileSet, not actual work, return it
-        return @work if @work.is_a? FileSet
+        return @work if @work.is_a?(Hyrax::FileSet) || @work.is_a?(FileSet)
         # in most cases, get from work's members:
-        filesets = @work.members.select { |m| m.is_a? FileSet }
+        filesets = @work.members.select { |m| m.is_a?(Hyrax::FileSet) || m.is_a?(FileSet) }
         filesets.empty? ? nil : filesets[0]
       end
     end

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -64,17 +64,28 @@ module IiifPrint
       # The ActiveFedora::Base indexer for FileSets
       IiifPrint::FileSetIndexer.decorate(Hyrax::FileSetIndexer)
 
-      if defined? Hyrax::Indexers::FileSetIndexer
-        # Newer versions of Hyrax favor `Hyrax::Indexers::FileSetIndexer` and deprecate
-        # `Hyrax::ValkyrieFileSetIndexer`.
-        IiifPrint::FileSetIndexer.decorate(Hyrax::Indexers::FileSetIndexer)
-      elsif defined? Hyrax::ValkyrieFileSetIndexer
-        # Versions 3.0+ of Hyrax have `Hyrax::ValkyrieFileSetIndexer` so we want to decorate that as
-        # well.  We want to use the elsif construct because later on Hyrax::ValkyrieFileSetIndexer
-        # inherits from Hyrax::Indexers::FileSetIndexer and only implements:
-        # `def initialize(*args); super; end`
-        IiifPrint::FileSetIndexer.decorate(Hyrax::ValkyrieFileSetIndexer)
-      end
+      # Newer versions of Hyrax favor `Hyrax::Indexers::FileSetIndexer` and deprecate
+      # `Hyrax::ValkyrieFileSetIndexer`.
+      IiifPrint::FileSetIndexer.decorate('Hyrax::Indexers::FileSetIndexer'.safe_constantize)
+
+      # Versions 3.0+ of Hyrax have `Hyrax::ValkyrieFileSetIndexer` so we want to decorate that as
+      # well.  We want to use the elsif construct because later on Hyrax::ValkyrieFileSetIndexer
+      # inherits from Hyrax::Indexers::FileSetIndexer and only implements:
+      # `def initialize(*args); super; end`
+      IiifPrint::FileSetIndexer.decorate('Hyrax::ValkyrieFileSetIndexer'.safe_constantize)
+
+      # # The ActiveFedora::Base indexer for Works
+      # IiifPrint::ChildWorkIndexer.decorate(Hyrax::WorkIndexer)
+
+      # # Newer versions of Hyrax favor `Hyrax::Indexers::PcdmObjectIndexer` and deprecate
+      # # `Hyrax::ValkyrieWorkIndexer`
+      # IiifPrint::ChildWorkIndexer.decorate('Hyrax::Indexers::PcdmObjectIndexer'.safe_constantize)
+
+      # # Versions 3.0+ of Hyrax have `Hyrax::ValkyrieWorkIndexer` so we want to decorate that as
+      # # well.  We want to use the elsif construct because later on Hyrax::ValkyrieWorkIndexer
+      # # inherits from Hyrax::Indexers::PcdmObjectIndexer and only implements:
+      # # `def initialize(*args); super; end`
+      # IiifPrint::ChildWorkIndexer.decorate('Hyrax::ValkyrieWorkIndexer'.safe_constantize)
 
       ::BlacklightIiifSearch::IiifSearchResponse.prepend(IiifPrint::IiifSearchResponseDecorator)
       ::BlacklightIiifSearch::IiifSearchAnnotation.prepend(IiifPrint::BlacklightIiifSearch::AnnotationDecorator)

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -64,30 +64,32 @@ module IiifPrint
       if ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYRAX_VALKYRIE', false))
         # Newer versions of Hyrax favor `Hyrax::Indexers::FileSetIndexer` and deprecate
         # `Hyrax::ValkyrieFileSetIndexer`.
-        IiifPrint::FileSetIndexer.decorate('Hyrax::Indexers::FileSetIndexer'.safe_constantize)
+        'Hyrax::Indexers::FileSetIndexer'.safe_constantize&.prepend(IiifPrint::FileSetIndexer)
 
         # Versions 3.0+ of Hyrax have `Hyrax::ValkyrieFileSetIndexer` so we want to decorate that as
         # well.  We want to use the elsif construct because later on Hyrax::ValkyrieFileSetIndexer
         # inherits from Hyrax::Indexers::FileSetIndexer and only implements:
         # `def initialize(*args); super; end`
-        IiifPrint::FileSetIndexer.decorate('Hyrax::ValkyrieFileSetIndexer'.safe_constantize)
+        'Hyrax::ValkyrieFileSetIndexer'.safe_constantize&.prepend(IiifPrint::FileSetIndexer)
+
+        # Newer versions of Hyrax favor `Hyrax::Indexers::PcdmObjectIndexer` and deprecate
+        # `Hyrax::ValkyrieWorkIndexer`
+        indexers = Hyrax.config.curation_concerns.map do |concern|
+          "#{concern}ResourceIndexer".safe_constantize
+        end
+        indexers.each { |indexer| indexer.prepend(IiifPrint::ChildWorkIndexer)}
+
+        # Versions 3.0+ of Hyrax have `Hyrax::ValkyrieWorkIndexer` so we want to decorate that as
+        # well.  We want to use the elsif construct because later on Hyrax::ValkyrieWorkIndexer
+        # inherits from Hyrax::Indexers::PcdmObjectIndexer and only implements:
+        # `def initialize(*args); super; end`
+        'Hyrax::ValkyrieWorkIndexer'.safe_constantize&.prepend(IiifPrint::ChildWorkIndexer)
       else
         # The ActiveFedora::Base indexer for FileSets
-        IiifPrint::FileSetIndexer.decorate(Hyrax::FileSetIndexer)
+        Hyrax::FileSetIndexer.prepend(IiifPrint::FileSetIndexer)
+        # The ActiveFedora::Base indexer for Works
+        Hyrax::WorkIndexer.prepend(IiifPrint::ChildWorkIndexer)
       end
-
-      # # The ActiveFedora::Base indexer for Works
-      # IiifPrint::ChildWorkIndexer.decorate(Hyrax::WorkIndexer)
-
-      # # Newer versions of Hyrax favor `Hyrax::Indexers::PcdmObjectIndexer` and deprecate
-      # # `Hyrax::ValkyrieWorkIndexer`
-      # IiifPrint::ChildWorkIndexer.decorate('Hyrax::Indexers::PcdmObjectIndexer'.safe_constantize)
-
-      # # Versions 3.0+ of Hyrax have `Hyrax::ValkyrieWorkIndexer` so we want to decorate that as
-      # # well.  We want to use the elsif construct because later on Hyrax::ValkyrieWorkIndexer
-      # # inherits from Hyrax::Indexers::PcdmObjectIndexer and only implements:
-      # # `def initialize(*args); super; end`
-      # IiifPrint::ChildWorkIndexer.decorate('Hyrax::ValkyrieWorkIndexer'.safe_constantize)
 
       ::BlacklightIiifSearch::IiifSearchResponse.prepend(IiifPrint::IiifSearchResponseDecorator)
       ::BlacklightIiifSearch::IiifSearchAnnotation.prepend(IiifPrint::BlacklightIiifSearch::AnnotationDecorator)

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -61,18 +61,20 @@ module IiifPrint
       Hyrax::WorkShowPresenter.prepend(IiifPrint::WorkShowPresenterDecorator)
       Hyrax::IiifHelper.prepend(IiifPrint::IiifHelperDecorator)
 
-      # The ActiveFedora::Base indexer for FileSets
-      IiifPrint::FileSetIndexer.decorate(Hyrax::FileSetIndexer)
+      if ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYRAX_VALKYRIE', false))
+        # Newer versions of Hyrax favor `Hyrax::Indexers::FileSetIndexer` and deprecate
+        # `Hyrax::ValkyrieFileSetIndexer`.
+        IiifPrint::FileSetIndexer.decorate('Hyrax::Indexers::FileSetIndexer'.safe_constantize)
 
-      # Newer versions of Hyrax favor `Hyrax::Indexers::FileSetIndexer` and deprecate
-      # `Hyrax::ValkyrieFileSetIndexer`.
-      IiifPrint::FileSetIndexer.decorate('Hyrax::Indexers::FileSetIndexer'.safe_constantize)
-
-      # Versions 3.0+ of Hyrax have `Hyrax::ValkyrieFileSetIndexer` so we want to decorate that as
-      # well.  We want to use the elsif construct because later on Hyrax::ValkyrieFileSetIndexer
-      # inherits from Hyrax::Indexers::FileSetIndexer and only implements:
-      # `def initialize(*args); super; end`
-      IiifPrint::FileSetIndexer.decorate('Hyrax::ValkyrieFileSetIndexer'.safe_constantize)
+        # Versions 3.0+ of Hyrax have `Hyrax::ValkyrieFileSetIndexer` so we want to decorate that as
+        # well.  We want to use the elsif construct because later on Hyrax::ValkyrieFileSetIndexer
+        # inherits from Hyrax::Indexers::FileSetIndexer and only implements:
+        # `def initialize(*args); super; end`
+        IiifPrint::FileSetIndexer.decorate('Hyrax::ValkyrieFileSetIndexer'.safe_constantize)
+      else
+        # The ActiveFedora::Base indexer for FileSets
+        IiifPrint::FileSetIndexer.decorate(Hyrax::FileSetIndexer)
+      end
 
       # # The ActiveFedora::Base indexer for Works
       # IiifPrint::ChildWorkIndexer.decorate(Hyrax::WorkIndexer)

--- a/lib/iiif_print/lineage_service.rb
+++ b/lib/iiif_print/lineage_service.rb
@@ -52,6 +52,8 @@ module IiifPrint
     # https://github.com/samvera/hyrax/blob/2b807fe101176d594129ef8a8fe466d3d03a372b/app/indexers/hyrax/work_indexer.rb#L15-L18
     # for "clarification" of the comingling of file_set_ids and member_ids
     def self.descendent_member_ids_for(object)
+      return unless object.respond_to?(:member_ids)
+
       # enables us to return parents when searching for child OCR
       #
       # https://github.com/samvera/hydra-works/blob/c9b9dd0cf11de671920ba0a7161db68ccf9b7f6d/lib/hydra/works/models/concerns/work_behavior.rb#L90-L92
@@ -60,7 +62,7 @@ module IiifPrint
       # so no sense doing `object.file_set_ids + object.member_ids`
       file_set_ids = object.member_ids
       IiifPrint.object_ordered_works(object)&.each do |child|
-        file_set_ids += descendent_member_ids_for(child)
+        file_set_ids += Array.wrap(descendent_member_ids_for(child))
       end
       # We must convert these to strings as Valkyrie's identifiers will be cast to hashes when we
       # attempt to write the SolrDocument.

--- a/lib/iiif_print/persistence_layer.rb
+++ b/lib/iiif_print/persistence_layer.rb
@@ -31,6 +31,13 @@ module IiifPrint
       end
 
       ##
+      # @param work_type [Class]
+      # @return the corresponding indexer for the work_type
+      def self.decorate_form_with_adapter_logic(work_type:)
+        raise NotImplementedError, "#{self}.{__method__}"
+      end
+
+      ##
       # @param file_set [Object]
       # @param work [Object]
       # @param model [Class] The class name for which we'll split children.

--- a/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
+++ b/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
@@ -24,6 +24,13 @@ module IiifPrint
       end
 
       ##
+      # @param work_type [Class<ActiveFedora::Base>]
+      # @return indexer for the given :work_type
+      def self.decorate_form_with_adapter_logic(work_type:)
+        work_type.indexer
+      end
+
+      ##
       # Return the immediate parent of the given :file_set.
       #
       # @param file_set [FileSet]

--- a/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
+++ b/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
@@ -29,6 +29,15 @@ module IiifPrint
       end
 
       ##
+      # @param work_type [Class<ActiveFedora::Base>]
+      # @return form for the given :work_type
+      def self.decorate_form_with_adapter_logic(work_type:)
+        form = "#{work_type}Form".constantize
+        form.send(:include, Hyrax::FormFields(:child_works_from_pdf_splitting)) unless form.included_modules.include?(Hyrax::FormFields(:child_works_from_pdf_splitting))
+        form
+      end
+
+      ##
       # Return the immediate parent of the given :file_set.
       #
       # @param file_set [FileSet]

--- a/spec/listeners/iiif_print/listener_spec.rb
+++ b/spec/listeners/iiif_print/listener_spec.rb
@@ -3,13 +3,18 @@
 require 'spec_helper'
 
 RSpec.describe IiifPrint::Listener do
-  describe '#on_file_set_attached' do
-    subject { described_class.new.on_file_set_attached(event) }
+  describe '#on_file_characterized' do
+    subject { described_class.new.on_file_characterized(event) }
     let(:file_set) { double(Hyrax::FileSet, file_set?: true) }
+    let(:file_metadata) { double(Hyrax::FileMetadata) }
     let(:user) { double(User) }
     let(:event) { { user: user, file_set: file_set } }
 
-    before { allow(IiifPrint).to receive(:parent_for).with(file_set).and_return(parent) }
+    before do
+      allow(IiifPrint).to receive(:parent_for).with(file_set).and_return(parent)
+      allow(file_set).to receive(:original_file).and_return(file_metadata)
+      allow(file_metadata).to receive(:pdf?).and_return(true)
+    end
 
     context 'without a parent work' do
       let(:parent) { nil }
@@ -24,8 +29,9 @@ RSpec.describe IiifPrint::Listener do
       let(:parent) { double(Valkyrie::Resource) }
 
       it "calls the service's #conditionally_enqueue method" do
+        allow(parent).to receive(:depositor).and_return(double('User'))
+
         expect(IiifPrint::SplitPdfs::ChildWorkCreationFromPdfService).to receive(:conditionally_enqueue)
-        expect(file_set).to receive(:original_file).and_return(double)
         subject
       end
     end

--- a/spec/listeners/iiif_print/listener_spec.rb
+++ b/spec/listeners/iiif_print/listener_spec.rb
@@ -36,38 +36,4 @@ RSpec.describe IiifPrint::Listener do
       end
     end
   end
-
-  describe '#on_object_membership_updated' do
-    class Work < Hyrax::Work
-      include Hyrax::Schema(:child_works_from_pdf_splitting)
-
-      def iiif_print_config?
-        true
-      end
-    end
-
-    subject { described_class.new.on_object_membership_updated(event) }
-
-    let(:event) { { object: parent_work } }
-    let(:parent_work) do
-      parent_work = Work.new
-      parent_work.title = ['Parent Work']
-      Hyrax.persister.save(resource: parent_work)
-    end
-    let(:child_work) do
-      child_work = Work.new
-      child_work.title = ['Child Work']
-      Hyrax.persister.save(resource: child_work)
-    end
-
-    before do
-      parent_work.member_ids << child_work.id
-      Hyrax.persister.save(resource: parent_work)
-      Hyrax.index_adapter.save(resource: parent_work)
-    end
-
-    it 'sets the is_child flag on the child work' do
-      expect { subject }.to change { Hyrax.query_service.find_by(id: child_work.id).is_child }.to(true)
-    end
-  end
 end


### PR DESCRIPTION
# Story

Refs https://github.com/scientist-softserv/iiif_print/issues/343

# Expected Behavior Before Changes

PDFs do not split into child works.

# Expected Behavior After Changes

PDFs split into child works and parent & children contain appropriate indexed values.

# Notes

Universal viewer does not work, at least locally.
