### PR TITLE
A few bug fixes

### DIFF
--- a/config/metadata/child_works_from_pdf_splitting.yaml
+++ b/config/metadata/child_works_from_pdf_splitting.yaml
@@ -4,10 +4,6 @@ attributes:
     multiple: false
     index_keys:
       - "is_child_bsi"
-    form:
-      required: false
-      primary: false
-      multiple: false
     predicate: "http://id.loc.gov/vocabulary/identifiers/isChild"
   split_from_pdf_id:
     type: string

--- a/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
+++ b/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
@@ -91,7 +91,7 @@ module IiifPrint
       end
 
       def self.pdf?(file_set)
-        file_set.original_file.pdf?
+        file_set.original_file&.pdf?
       end
 
       ##


### PR DESCRIPTION
## 🐛 Add guard for nil original_file

21100a9f5b9c53bd3649518d4f9e39f93699cbb5

If ever the original_file hasn't been set, we want to guard against a
NoMethodError for NilClass.

## 🐛 Remove form keys from is_child

2e4af9281cfd4a38aacfeae4ded42f10ace6763f

Because we have the form keys when the work gets created, `is_child` is
set to `''` and not `nil`. This causes any queries that look for
`is_child` being `nil` to not work.
