### PR TITLE
🐛 Add lonely operator for defensive coding

### DIFF
--- a/lib/iiif_print/base_derivative_service.rb
+++ b/lib/iiif_print/base_derivative_service.rb
@@ -33,7 +33,7 @@ module IiifPrint
       # @TODO: verify if this works for ActiveFedora and if so, remove commented code.
       #        If not, modify to use adapter.
       # file_set.class.image_mime_types.include?(file_set.mime_type)
-      file_set.original_file.image?
+      file_set.original_file&.image?
     end
 
     def derivative_path_factory


### PR DESCRIPTION
Adds lonely operator per Rob's recommendation for defensive coding, even if, ideally, original_file shouldn't be nil.

We originally noticed an error when running iiif print split locally, from Hyku. 

```
NoMethodError (undefined method `image?' for nil:NilClass):
/usr/local/bundle/bundler/gems/iiif_print-675115934432/lib/iiif_print/base_derivative_service.rb:36:in `valid?'
```

