### PR TITLE
Update child_works_from_pdf_splitting.yaml

### DIFF
--- a/config/metadata/child_works_from_pdf_splitting.yaml
+++ b/config/metadata/child_works_from_pdf_splitting.yaml
@@ -10,8 +10,4 @@ attributes:
     multiple: false
     index_keys:
       - "split_from_pdf_id_ssi"
-    form:
-      required: false
-      primary: false
-      multiple: false
     predicate: "http://id.loc.gov/vocabulary/identifiers/splitFromPdfId"


### PR DESCRIPTION
This should have been removed in this https://github.com/scientist-softserv/iiif_print/pull/354/files#diff-62878557e3774c98dbc531227f3fa9afaf90403a6b2b60a0a681825f42521e87. I'm not sure how it found its way back in main.

