### PR TITLE
Hide custom terms from resource forms

### DIFF
--- a/config/metadata/child_works_from_pdf_splitting.yaml
+++ b/config/metadata/child_works_from_pdf_splitting.yaml
@@ -4,6 +4,11 @@ attributes:
     multiple: false
     index_keys:
       - "is_child_bsi"
+    form:
+      display: false
+      required: false
+      primary: false
+      multiple: false
     predicate: "http://id.loc.gov/vocabulary/identifiers/isChild"
   split_from_pdf_id:
     type: string
@@ -11,6 +16,7 @@ attributes:
     index_keys:
       - "split_from_pdf_id_ssi"
     form:
+      display: false
       required: false
       primary: false
       multiple: false


### PR DESCRIPTION
# Story

This is a partial fix for https://github.com/scientist-softserv/hykuup_knapsack/issues/240 and is tied in with a change in hyrax to support `display: false`

# Expected Behavior Before Changes

IiifPrint custom terms always appear on resource forms.

# Expected Behavior After Changes
IiifPrint custom terms can be hidden via yaml `display: false` in the form definition.
# Screenshots / Video

<details>
<summary>Screenshots</summary>

## Before
![Screenshot 2024-06-20 at 2 31 04 PM](https://github.com/scientist-softserv/iiif_print/assets/17851674/ba0669b9-3a73-4226-b880-7aa62ba47262)

## After
![Screenshot 2024-06-20 at 2 29 46 PM](https://github.com/scientist-softserv/iiif_print/assets/17851674/0e6900c4-5ba8-4c80-a78b-9a2d90d5849e)

</details>

# Notes