### PR TITLE
Replace #lease_release_date with #lease_expiration_date

### DIFF
--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -212,7 +212,7 @@ module IiifPrint
             visibility: 'lease',
             visibility_after_lease: lease.visibility_after_lease,
             visibility_during_lease: lease.visibility_during_lease,
-            lease_release_date: lease.lease_release_date
+            lease_release_date: lease.lease_expiration_date
           }
         else
           visibility_params = { visibility: parent_work.visibility.to_s }


### PR DESCRIPTION
#lease_release_date is not a valid method so threw an error when running jobs to create relationships. Replace method with #lease_expiration_date.

Valid lease methods include:

```
parent_work.lease.methods.grep(/lease/)=>
[:visibility_after_lease=,
 :lease_history=,
 :lease_expiration_date,
 :lease_expiration_date=,
 :lease_history,
 :visibility_after_lease,
 :visibility_during_lease,
 :visibility_during_lease=]
```

# Story

Jobs seemed to have split but create relationships failed, so it doesn't look like it worked.  

[ref](https://dev.pals.test/dashboard/my/works?locale=en)

# Screenshots / Video
Error from the server
![image (68)](https://github.com/scientist-softserv/iiif_print/assets/10081604/d90a0015-a60e-4245-8c44-01f86fbda27d)




# Notes