### PR TITLE
⚙️ Utilize Hyrax's schema search paths config

### DIFF
--- a/.github/workflows/build-lint-test-action.yaml
+++ b/.github/workflows/build-lint-test-action.yaml
@@ -16,17 +16,16 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.13
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.15
     secrets: inherit
     with:
       platforms: "linux/amd64"
-      target: hyku-base
-      worker: false
+      webTarget: hyku-base
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.13
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.15
     with:
       setup_db_cmd: bundle exec rake prepare_and_run_tests
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.13
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.15

--- a/app/services/iiif_print/simple_schema_loader_decorator.rb
+++ b/app/services/iiif_print/simple_schema_loader_decorator.rb
@@ -9,4 +9,4 @@ module IiifPrint
     end
   end
 end
-Hyrax::SimpleSchemaLoader.prepend(IiifPrint::SimpleSchemaLoaderDecorator)
+Hyrax::SimpleSchemaLoader.prepend(IiifPrint::SimpleSchemaLoaderDecorator) unless Hyrax.config.respond_to?(:simple_schema_loader_config_search_paths)

--- a/lib/iiif_print/engine.rb
+++ b/lib/iiif_print/engine.rb
@@ -65,6 +65,8 @@ module IiifPrint
         config.callback.set(:after_create_fileset) do |file_set, user|
           IiifPrint.config.handle_after_create_fileset(file_set, user)
         end
+
+        config.simple_schema_loader_config_search_paths += [IiifPrint::Engine.root] if config.respond_to?(:simple_schema_loader_config_search_paths)
       end
     end
     # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
As of Hyrax `9d8d5f8`, there is now a configuration for the `Hyrax::SimpleSchemaLoader` that allows us to do away with the need for a decorator.  I'm leaving it there for applications that aren't at `9d8d5f8` yet but guard it.

Ref:
  - https://github.com/samvera/hyrax/commit/9d8d5f8dad116f9143e985e57ed26fd2543d4ec6
