### PR TITLE
Fix handling of arrays with blank strings

### DIFF
--- a/app/helpers/iiif_print/iiif_print_helper_behavior.rb
+++ b/app/helpers/iiif_print/iiif_print_helper_behavior.rb
@@ -7,7 +7,7 @@ module IiifPrint::IiifPrintHelperBehavior
   # rubocop:disable Rails/OutputSafety
   def render_ocr_snippets(options = {})
     snippets = options[:value]
-    return if snippets.blank?
+    return if snippets.all?(&:blank?)
 
     snippets_content = [content_tag('div',
                                     "... #{snippets.first} ...".html_safe,


### PR DESCRIPTION
- Updated the logic to correctly identify arrays that contain only blank or empty strings.
- Replaced `.blank?` check with `snippets.all?(&:blank?)` to ensure arrays like [""] are handled as blank.
- This prevents issues where non-empty arrays with blank elements were not treated as blank.

# Story

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes