### PR TITLE
🐛 Handle blank query and snippets

### DIFF
--- a/app/helpers/iiif_print/iiif_print_helper_behavior.rb
+++ b/app/helpers/iiif_print/iiif_print_helper_behavior.rb
@@ -7,7 +7,7 @@ module IiifPrint::IiifPrintHelperBehavior
   # rubocop:disable Rails/OutputSafety
   def render_ocr_snippets(options = {})
     snippets = options[:value]
-    return if snippets.blank?
+    return if snippets.blank? || params[:q].blank?
 
     snippets_content = [content_tag('div',
                                     "... #{snippets.first} ...".html_safe,


### PR DESCRIPTION
# Story

This commit will address blank catalog searches and how it interacts with snippets.  Prior, when the user submitted a blank catalog search, the entire indexed text will be returned.  This is not desired because if we're looking at a book with a hundred pages, then that's a lot of rendered text.  Instead, if we don't have a query string then we will also return.

# Expected Behavior Before Changes
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/8700187f-5824-4347-819c-55ce3ffc9ed9">


# Expected Behavior After Changes
<img width="1088" alt="image" src="https://github.com/user-attachments/assets/c4ccbef1-e5b3-4b85-a727-36780cac9918">
