### PR TITLE
Remediate fileset duplication in items list

### DIFF
--- a/app/indexers/concerns/iiif_print/child_work_indexer_decorator.rb
+++ b/app/indexers/concerns/iiif_print/child_work_indexer_decorator.rb
@@ -21,7 +21,7 @@ module IiifPrint
       solr_doc['is_child_bsi'] ||= object.try(:is_child)
       solr_doc['split_from_pdf_id_ssi'] ||= object.try(:split_from_pdf_id)
       solr_doc['is_page_of_ssim'] = iiif_print_lineage_service.ancestor_ids_for(object)
-      solr_doc['member_ids_ssim'] = iiif_print_lineage_service.descendent_member_ids_for(object)
+      solr_doc['descendent_member_ids_ssim'] = iiif_print_lineage_service.descendent_member_ids_for(object)
     end
   end
 end

--- a/app/models/concerns/iiif_print/solr_document_decorator.rb
+++ b/app/models/concerns/iiif_print/solr_document_decorator.rb
@@ -15,11 +15,9 @@ module IiifPrint
       iiif_print_solr_field_names.include?(method_name.to_s) || super
     end
 
-    # @see https://github.com/samvera/hyrax/commit/7108409c619cd2ba4ae8c836b9f3b429a7e9837b
+    # consists of member_ids_ssim + its descendents' member_ids (recursively)
     def file_set_ids
-      # Yes, this looks a little odd.  But the truth is the prior key (e.g. `file_set_ids_ssim`) was
-      # an alias of `member_ids_ssim`.
-      self['member_ids_ssim']
+      self['descendent_member_ids_ssim'] || self['member_ids_ssim']
     end
 
     def any_highlighting?

--- a/app/presenters/iiif_print/iiif_manifest_presenter_factory_decorator.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_factory_decorator.rb
@@ -14,7 +14,7 @@ module IiifPrint
           presenter_class.for(solr_doc)
         elsif Hyrax.config.curation_concerns.include?(solr_doc.hydra_model)
           # look up file set ids and loop through those
-          file_set_docs = load_file_set_docs(load_file_set_ids) 
+          file_set_docs = load_file_set_docs(load_file_set_ids)
           file_set_docs.map { |doc| presenter_class.for(doc) } if file_set_docs.length
         end
       end.flatten.compact
@@ -24,9 +24,9 @@ module IiifPrint
 
     def load_file_set_ids(solr_doc)
       solr_doc.try(:descendent_member_ids_ssim) ||
-      solr_doc.try(:[], 'descendent_member_ids_ssim') ||
-      solr_doc.try(:member_ids_ssim) ||
-      solr_doc.try(:[], 'member_ids_ssim')
+        solr_doc.try(:[], 'descendent_member_ids_ssim') ||
+        solr_doc.try(:member_ids_ssim) ||
+        solr_doc.try(:[], 'member_ids_ssim')
     end
 
     # still create the manifest if the parent work has images attached but the child works do not

--- a/app/presenters/iiif_print/iiif_manifest_presenter_factory_decorator.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_factory_decorator.rb
@@ -14,7 +14,7 @@ module IiifPrint
           presenter_class.for(solr_doc)
         elsif Hyrax.config.curation_concerns.include?(solr_doc.hydra_model)
           # look up file set ids and loop through those
-          file_set_docs = load_file_set_docs(load_file_set_ids)
+          file_set_docs = load_file_set_docs(load_file_set_ids(solr_doc))
           file_set_docs.map { |doc| presenter_class.for(doc) } if file_set_docs.length
         end
       end.flatten.compact

--- a/app/presenters/iiif_print/iiif_manifest_presenter_factory_decorator.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter_factory_decorator.rb
@@ -14,13 +14,20 @@ module IiifPrint
           presenter_class.for(solr_doc)
         elsif Hyrax.config.curation_concerns.include?(solr_doc.hydra_model)
           # look up file set ids and loop through those
-          file_set_docs = load_file_set_docs(solr_doc.try(:member_ids) || solr_doc.try(:[], 'member_ids_ssim'))
+          file_set_docs = load_file_set_docs(load_file_set_ids) 
           file_set_docs.map { |doc| presenter_class.for(doc) } if file_set_docs.length
         end
       end.flatten.compact
     end
 
     private
+
+    def load_file_set_ids(solr_doc)
+      solr_doc.try(:descendent_member_ids_ssim) ||
+      solr_doc.try(:[], 'descendent_member_ids_ssim') ||
+      solr_doc.try(:member_ids_ssim) ||
+      solr_doc.try(:[], 'member_ids_ssim')
+    end
 
     # still create the manifest if the parent work has images attached but the child works do not
     def load_file_set_docs(file_set_ids)

--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -33,9 +33,9 @@ module IiifPrint
 
     def load_file_set_ids(solr_doc)
       solr_doc.try(:descendent_member_ids_ssim) ||
-      solr_doc.try(:[], 'descendent_member_ids_ssim') ||
-      solr_doc.try(:member_ids_ssim) ||
-      solr_doc.try(:[], 'member_ids_ssim')
+        solr_doc.try(:[], 'descendent_member_ids_ssim') ||
+        solr_doc.try(:member_ids_ssim) ||
+        solr_doc.try(:[], 'member_ids_ssim')
     end
 
     # This method allows for overriding to add additional file types to mix in with IiifAv

--- a/app/presenters/iiif_print/work_show_presenter_decorator.rb
+++ b/app/presenters/iiif_print/work_show_presenter_decorator.rb
@@ -24,11 +24,18 @@ module IiifPrint
     #
     # @todo Review if this is necessary for Hyrax 5.
     def members_include_viewable_image?
-      all_member_ids = solr_document.try(:member_ids) || solr_document.try(:[], 'member_ids_ssim')
+      all_member_ids = load_file_set_ids(solr_document)
       Array.wrap(all_member_ids).each do |id|
         return true if file_type_and_permissions_valid?(member_presenters_for([id]).first)
       end
       false
+    end
+
+    def load_file_set_ids(solr_doc)
+      solr_doc.try(:descendent_member_ids_ssim) ||
+      solr_doc.try(:[], 'descendent_member_ids_ssim') ||
+      solr_doc.try(:member_ids_ssim) ||
+      solr_doc.try(:[], 'member_ids_ssim')
     end
 
     # This method allows for overriding to add additional file types to mix in with IiifAv

--- a/app/services/iiif_print/manifest_builder_service_decorator.rb
+++ b/app/services/iiif_print/manifest_builder_service_decorator.rb
@@ -79,7 +79,7 @@ module IiifPrint
       # uses the 'id' property for v3 manifest and `@id' for v2, which is a URL that contains the FileSet id
       file_set_id = (canvas['id'] || canvas['@id']).split('/').last
       # finds the image that the FileSet is attached to and creates metadata on that canvas
-      image = solr_doc_hits.find { |hit| hit[:descendent_member_ids_ssim]&.include?(file_set_id) }
+      image = solr_doc_hits.find { |hit| (hit[:descendent_member_ids_ssim] || hit[:member_ids_ssim])&.include?(file_set_id) }
       return unless image
       # prevents duplicating the child and parent metadata
       return if image.id == presenter.id

--- a/app/services/iiif_print/manifest_builder_service_decorator.rb
+++ b/app/services/iiif_print/manifest_builder_service_decorator.rb
@@ -79,7 +79,7 @@ module IiifPrint
       # uses the 'id' property for v3 manifest and `@id' for v2, which is a URL that contains the FileSet id
       file_set_id = (canvas['id'] || canvas['@id']).split('/').last
       # finds the image that the FileSet is attached to and creates metadata on that canvas
-      image = solr_doc_hits.find { |hit| hit[:member_ids_ssim]&.include?(file_set_id) }
+      image = solr_doc_hits.find { |hit| hit[:descendent_member_ids_ssim]&.include?(file_set_id) }
       return unless image
       # prevents duplicating the child and parent metadata
       return if image.id == presenter.id
@@ -124,7 +124,7 @@ module IiifPrint
     end
 
     def member_ids_for(presenter)
-      member_ids = presenter.try(:ordered_ids) || presenter.try(:member_ids)
+      member_ids = presenter.object.solr_document['descendent_member_ids_ssim'] || presenter.try(:ordered_ids) || presenter.try(:member_ids)
       member_ids.nil? ? [] : member_ids
     end
 

--- a/lib/iiif_print/blacklight_iiif_search/annotation_decorator.rb
+++ b/lib/iiif_print/blacklight_iiif_search/annotation_decorator.rb
@@ -2,7 +2,7 @@
 module IiifPrint
   module BlacklightIiifSearch
     module AnnotationDecorator
-      INVALID_MATCH_TEXT = "#xywh=INVALID,INVALID,INVALID,INVALID".freeze
+      INVALID_MATCH_TEXT = "#xywh=0,0,0,0".freeze
       ##
       # Create a URL for the annotation
       # use a Hyrax-y URL syntax:

--- a/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
+++ b/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
@@ -12,9 +12,7 @@ module IiifPrint
       # @param object [Valkyrie::Resource]
       # @return [Array<Valkyrie::Resource>]
       def self.object_ordered_works(object)
-        child_file_sets = Hyrax.custom_queries.find_child_file_sets(resource: object).to_a
-        child_works = Hyrax.custom_queries.find_child_works(resource: object).to_a
-        child_works + child_file_sets
+        Hyrax.custom_queries.find_child_works(resource: object).to_a
       end
 
       ##

--- a/spec/factories/newspaper_page_solr_document.rb
+++ b/spec/factories/newspaper_page_solr_document.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
           title_tesim: ['Page 1'],
           has_model_ssim: ['NewspaperPage'],
           issue_id_ssi: 'abc123',
-          member_ids_ssim: [file_set.id],
+          descendent_member_ids_ssim: [file_set.id],
           thumbnail_path_ss: '/downloads/123456?file=thumbnail')
     end
   end

--- a/spec/factories/newspaper_page_solr_document.rb
+++ b/spec/factories/newspaper_page_solr_document.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
           title_tesim: ['Page 1'],
           has_model_ssim: ['NewspaperPage'],
           issue_id_ssi: 'abc123',
+          member_ids_ssim: [file_set.id],
           descendent_member_ids_ssim: [file_set.id],
           thumbnail_path_ss: '/downloads/123456?file=thumbnail')
     end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 RSpec.describe SolrDocument do
-  let(:solr_doc) { described_class.new(id: 'foo', member_ids_ssim: ['bar']) }
+  let(:solr_doc) { described_class.new(id: 'foo', descendent_member_ids_ssim: ['bar']) }
 
   describe 'file_set_ids' do
     it 'responds to #file_set_ids' do

--- a/spec/presenters/iiif_print/iiif_manifest_presenter_factory_decorator_spec.rb
+++ b/spec/presenters/iiif_print/iiif_manifest_presenter_factory_decorator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe IiifPrint::IiifManifestPresenterDecorator do
     { "id" => "child_work123",
       "title_tesim" => ["My Child Image"],
       "has_model_ssim" => ["Image"],
-      "member_ids_ssim" => ["child_image_fs123"] }
+      "descendent_member_ids_ssim" => ["child_image_fs123"] }
   end
   let(:child_fs_attributes) do
     { "id" => "child_fs123",


### PR DESCRIPTION
# Story

Refs https://github.com/scientist-softserv/adventist_knapsack/issues/817

IiifPrint previously updated `member_ids` to include the child work's filesets. After Valkyrization, this resulted in the inclusion of both the pages & child works in the items list. By removing the override of `member_ids` and indexing `descendent_member_ids_ssim`, we now separated the inclusion of the descendent's filesets to only those situations where the behavior is desired.

Additionally, searching from the parent work was broken because the PDF files do not have text extraction and were returning invalid results.

# Expected Behavior Before Changes

- Child works & child filesets both show in items list.
- Universal Viewer text search did not work at the parent work level. 

# Expected Behavior After Changes

- Only child works show in items list.
- Universal viewer shows each page only once.
- Universal viewer search works from either parent or child works.

# Screenshots / Video

<details>
<summary>Before</summary>

## Items List
![Screenshot 2024-09-25 at 1 16 27 PM](https://github.com/user-attachments/assets/657d6379-7efc-4f33-addc-cce350d9abdc)

</details>

<details>
<summary>After</summary>

## Items List
![Screenshot 2024-09-25 at 1 22 31 PM](https://github.com/user-attachments/assets/70e1e285-9ec5-46c4-95af-3c23c7653699)

## Search for word that exists
![Screenshot 2024-09-25 at 1 18 50 PM](https://github.com/user-attachments/assets/11ad31ce-a644-4fdc-a367-c1489da12a75)

## Search for word that doesn't exist
![Screenshot 2024-09-25 at 1 17 39 PM](https://github.com/user-attachments/assets/4047d55a-2411-45ae-a71a-843e88c1fb26)

</details>

# Notes

Fix requires a reindex of works to redefine the indexed value of `member_ids_ssim` and to index `descendent_member_ids_ssim` instead. Prior to a reindex, the items list will continue to contain both child works and their filesets.