### PR TITLE
Increase ImageMagick resource limits to prevent SIGKILL on large image processing

### DIFF
--- a/config/vendor/imagemagick-6-policy.xml
+++ b/config/vendor/imagemagick-6-policy.xml
@@ -49,12 +49,12 @@
   -->
 
   <!-- IiifPrint: allow more than default Ubuntu policy, re: RAM, Disk -->
-  <policy domain="resource" name="memory" value="512MiB"/>
-  <policy domain="resource" name="map" value="1GiB"/>
-  <policy domain="resource" name="width" value="20KP"/>
-  <policy domain="resource" name="height" value="20KP"/>
-  <policy domain="resource" name="area" value="128MB"/>
-  <policy domain="resource" name="disk" value="2GiB"/>
+  <policy domain="resource" name="memory" value="16GiB"/>
+  <policy domain="resource" name="map" value="32GiB"/>
+  <policy domain="resource" name="disk" value="200GiB"/>
+  <policy domain="resource" name="width" value="100KP"/>
+  <policy domain="resource" name="height" value="100KP"/>
+  <policy domain="resource" name="area" value="500GiB"/>
 
   <policy domain="cache" name="shared-secret" value="passphrase"/>
   <policy domain="coder" rights="none" pattern="EPHEMERAL" />

--- a/lib/iiif_print/image_tool.rb
+++ b/lib/iiif_print/image_tool.rb
@@ -74,8 +74,11 @@ module IiifPrint
 
     # @return [Array<String>] lines of output from imagemagick `identify`
     def im_identify
-      cmd = "identify -format 'Geometry: %G\nDepth: %[bit-depth]\nColorspace: %[colorspace]\nAlpha: %A\nMIME type: %m\n' #{path}"
-      `#{cmd}`.lines
+      cmd = "identify -limit memory 8GiB -limit map 16GiB -limit disk 50GiB -format 'Geometry: %G\nDepth: %[bit-depth]\nColorspace: %[colorspace]\nAlpha: %A\nMIME type: %m\n' #{path}"
+      output, status = Open3.capture2(cmd)
+      Rails.logger.info "Identify command output: #{output}"
+      Rails.logger.info "Identify command status: #{status}"
+      output.lines
     end
 
     def im_mime(lines)


### PR DESCRIPTION
- Updated `imagemagick-6-policy.xml` to allocate higher memory, map, and disk limits for ImageMagick processes, accommodating large TIFF files.
- Adjusted `im_identify` in `image_tool` to set specific resource constraints on memory, map, and disk, reducing risk of process termination.
- This change addresses out-of-memory issues when processing high-resolution images in ValkyrieCreateDerivativesJob.

### AFTER

![image](https://github.com/user-attachments/assets/d1613b68-7396-4b91-8e56-2a780729de0d)


### BEFORE

![image](https://github.com/user-attachments/assets/600bbd35-6990-4a07-9d9a-c25d45b34c2c)
