### PR TITLE
i876 - Make memory, map, and disk limits in `im_identify` configurable

### DIFF
--- a/lib/iiif_print/configuration.rb
+++ b/lib/iiif_print/configuration.rb
@@ -4,6 +4,12 @@ module IiifPrint
     attr_writer :after_create_fileset_handler
 
     attr_writer :ingest_queue_name
+
+    # Example settings in the initializer:
+    # config.memory_limit = "512MiB"  # Limit for memory usage
+    # config.map_limit = "1GiB"       # Limit for map usage
+    # config.disk_limit = "20KP"      # Limit for disk usage
+    attr_accessor :memory_limit, :map_limit, :disk_limit
     ##
     # @return [Symbol, Proc]
     def ingest_queue_name

--- a/lib/iiif_print/image_tool.rb
+++ b/lib/iiif_print/image_tool.rb
@@ -74,12 +74,12 @@ module IiifPrint
 
     # @return [Array<String>] lines of output from imagemagick `identify`
     def im_identify
-      memory_limit = ENV["IM_MEMORY_LIMIT"]
-      map_limit = ENV["IM_MAP_LIMIT"]
-      disk_limit = ENV["IM_DISK_LIMIT"]
+      memory_limit = IiifPrint.config.memory_limit
+      map_limit = IiifPrint.config.map_limit
+      disk_limit = IiifPrint.config.disk_limit
     
       cmd = "identify"
-    
+      
       cmd += " -limit memory #{memory_limit}" if memory_limit.present?
       cmd += " -limit map #{map_limit}" if map_limit.present?
       cmd += " -limit disk #{disk_limit}" if disk_limit.present?

--- a/lib/iiif_print/image_tool.rb
+++ b/lib/iiif_print/image_tool.rb
@@ -74,7 +74,18 @@ module IiifPrint
 
     # @return [Array<String>] lines of output from imagemagick `identify`
     def im_identify
-      cmd = "identify -limit memory 8GiB -limit map 16GiB -limit disk 50GiB -format 'Geometry: %G\nDepth: %[bit-depth]\nColorspace: %[colorspace]\nAlpha: %A\nMIME type: %m\n' #{path}"
+      memory_limit = ENV["IM_MEMORY_LIMIT"]
+      map_limit = ENV["IM_MAP_LIMIT"]
+      disk_limit = ENV["IM_DISK_LIMIT"]
+    
+      cmd = "identify"
+    
+      cmd += " -limit memory #{memory_limit}" if memory_limit.present?
+      cmd += " -limit map #{map_limit}" if map_limit.present?
+      cmd += " -limit disk #{disk_limit}" if disk_limit.present?
+    
+      cmd += " -format 'Geometry: %G\nDepth: %[bit-depth]\nColorspace: %[colorspace]\nAlpha: %A\nMIME type: %m\n' #{path}"
+      
       output, status = Open3.capture2(cmd)
       Rails.logger.info "Identify command output: #{output}"
       Rails.logger.info "Identify command status: #{status}"


### PR DESCRIPTION
- Added environment variable support for ImageMagick memory, map, and disk limits in the `im_identify` method
- Falls back to imagemagick-6-policy.xml defaults if no configuration is provided
- Improves flexibility and control over resource usage during image processing

Issue: 
- https://github.com/scientist-softserv/adventist_knapsack/issues/867