### PR TITLE
Make `digest_sha1` work for Valkyrie as well as Wings/Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,17 @@ We created IiifPrint with an assumption of ActiveFedora.  However, as Hyrax now 
 
 ### IIIF URL configuration
 
-If you set EXTERNAL_IIIF_URL in your environment, then IiifPrint will use that URL as the root for your IIIF URLs. It will also switch from using the file set ID to using the SHA1 of the file as the identifier. This enables using serverless_iiif or Cantaloupe (refered to as the service) by pointing the service to the same S3 bucket that FCREPO writes the uploaded files to. By setting it up that way you do not need the service to connect to FCREPO or Hyrax at all, both natively support connecting to an S3 bucket to get their data.
+If you set `EXTERNAL_IIIF_URL` in your environment, IiifPrint will use that URL as the root for your IIIF URLs. It will also switch from using the file set ID to using the file's checksum hex digest as the identifier. In Wings/Fedora mode the digest is stored as a `urn:sha1:HEX` string; in Valkyrie mode it is stored as a plain hex string — IiifPrint handles both automatically.
+
+This enables using serverless_iiif or Cantaloupe (referred to as the service) by pointing the service to the same S3 bucket that the repository writes uploaded files to. By setting it up that way you do not need the service to connect to Fedora or Hyrax at all — both natively support connecting to an S3 bucket to retrieve file content.
+
+If your S3 bucket organises files under a folder prefix (e.g. a `staging/` or `production/` subfolder), set `IIIF_S3_FOLDER_PREFIX` to that prefix. IiifPrint will prepend it to the digest identifier and percent-encode the separator so the combined value is a single IIIF path segment:
+
+```
+EXTERNAL_IIIF_URL=https://iiif.example.org
+IIIF_S3_FOLDER_PREFIX=staging
+# → identifier used: staging%2F<hex-digest>
+```
 
 ### Model level configurations
 

--- a/app/models/concerns/iiif_print/solr_document_decorator.rb
+++ b/app/models/concerns/iiif_print/solr_document_decorator.rb
@@ -2,8 +2,17 @@
 
 module IiifPrint
   module SolrDocumentDecorator
+    def digest_hex
+      raw = digest
+      return nil if raw.blank?
+      # Wings/Fedora stores "urn:sha1:HEX" or "urn:md5:HEX"; Valkyrie stores a plain hex string.
+      raw[/\Aurn:[^:]+:([\w]+)\z/, 1] || raw
+    end
+
     def digest_sha1
-      digest[/urn:sha1:([\w]+)/, 1]
+      Deprecation.warn(self, "#digest_sha1 is deprecated; use #digest_hex instead. " \
+                             "#digest_sha1 will be removed in the next major version.")
+      digest_hex
     end
 
     def method_missing(method_name, *args, &block)

--- a/app/presenters/iiif_print/iiif_manifest_presenter/display_image_presenter_decorator.rb
+++ b/app/presenters/iiif_print/iiif_manifest_presenter/display_image_presenter_decorator.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 # mixin to provide URL for IIIF Content Search service
 module IiifPrint
   module IiifManifestPresenter
@@ -82,7 +84,13 @@ module IiifPrint
       end
 
       def external_latest_file_id
-        @latest_file_id ||= digest_sha1
+        hex = digest_hex
+        return nil if hex.blank?
+
+        prefix = ENV['IIIF_S3_FOLDER_PREFIX'].presence
+        return hex unless prefix
+
+        CGI.escape("#{prefix}/#{hex}")
       end
 
       def iiif_image_url_builder(url_builder:)

--- a/app/transactions/hyrax/transactions/iiif_print_container_decorator.rb
+++ b/app/transactions/hyrax/transactions/iiif_print_container_decorator.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+begin
+  require 'dry/container'
+rescue LoadError
+  nil
+end
+
+# dry-transaction >= 0.15 dropped dry-container, so Dry::Container::Mixin is unavailable in those
+# environments. Guard the entire decorator so iiif_print still boots in Hyrax 2.x / newer dry-rb.
+return unless defined?(Dry::Container)
+
 module Hyrax
   module Transactions
     ##

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -2,6 +2,48 @@ require 'spec_helper'
 RSpec.describe SolrDocument do
   let(:solr_doc) { described_class.new(id: 'foo', descendent_member_ids_ssim: ['bar']) }
 
+  describe '#digest_hex' do
+    subject(:hex) { described_class.new('digest_ssim' => [raw]).digest_hex }
+
+    context 'with a urn:sha1 value (Wings/Fedora mode)' do
+      let(:raw) { 'urn:sha1:620cae0e5cf89d9a788cb7d8e31fcbfa78340284' }
+
+      it 'returns the hex portion' do
+        expect(hex).to eq '620cae0e5cf89d9a788cb7d8e31fcbfa78340284'
+      end
+    end
+
+    context 'with a urn:md5 value' do
+      let(:raw) { 'urn:md5:542cd898c5be91687e6c6f2c4f53f2d5' }
+
+      it 'returns the hex portion' do
+        expect(hex).to eq '542cd898c5be91687e6c6f2c4f53f2d5'
+      end
+    end
+
+    context 'with a plain hex string (Valkyrie mode)' do
+      let(:raw) { '542cd898c5be91687e6c6f2c4f53f2d5' }
+
+      it 'returns the hex string as-is' do
+        expect(hex).to eq '542cd898c5be91687e6c6f2c4f53f2d5'
+      end
+    end
+
+    context 'when digest_ssim is absent' do
+      subject(:hex) { described_class.new({}).digest_hex }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#digest_sha1' do
+    it 'is deprecated and delegates to #digest_hex' do
+      doc = described_class.new('digest_ssim' => ['urn:sha1:620cae0e5cf89d9a788cb7d8e31fcbfa78340284'])
+      expect(Deprecation).to receive(:warn)
+      expect(doc.digest_sha1).to eq doc.digest_hex
+    end
+  end
+
   describe 'file_set_ids' do
     it 'responds to #file_set_ids' do
       expect(solr_doc).to respond_to(:file_set_ids)

--- a/spec/presenters/iiif_print/iiif_manifest_presenter_decorator_spec.rb
+++ b/spec/presenters/iiif_print/iiif_manifest_presenter_decorator_spec.rb
@@ -1,5 +1,54 @@
 require 'spec_helper'
 
+RSpec.describe IiifPrint::IiifManifestPresenter::DisplayImagePresenterDecorator do
+  subject(:presenter) { Hyrax::IiifManifestPresenter::DisplayImagePresenter.new(solr_doc) }
+
+  let(:solr_doc) { SolrDocument.new('digest_ssim' => [digest_value]) }
+
+  before { allow(ENV).to receive(:[]).and_call_original }
+
+  describe '#external_latest_file_id' do
+    context 'with a plain MD5 hex string (Valkyrie mode), no prefix' do
+      let(:digest_value) { '542cd898c5be91687e6c6f2c4f53f2d5' }
+
+      before { allow(ENV).to receive(:[]).with('IIIF_S3_FOLDER_PREFIX').and_return(nil) }
+
+      it 'returns the hex as-is' do
+        expect(presenter.send(:external_latest_file_id)).to eq '542cd898c5be91687e6c6f2c4f53f2d5'
+      end
+    end
+
+    context 'with a plain MD5 hex string (Valkyrie mode), with prefix' do
+      let(:digest_value) { '542cd898c5be91687e6c6f2c4f53f2d5' }
+
+      before { allow(ENV).to receive(:[]).with('IIIF_S3_FOLDER_PREFIX').and_return('staging') }
+
+      it 'percent-encodes the slash so the key is a single IIIF path segment' do
+        expect(presenter.send(:external_latest_file_id)).to eq 'staging%2F542cd898c5be91687e6c6f2c4f53f2d5'
+      end
+    end
+
+    context 'with a urn:sha1 value (Wings/Fedora mode), no prefix' do
+      let(:digest_value) { 'urn:sha1:620cae0e5cf89d9a788cb7d8e31fcbfa78340284' }
+
+      before { allow(ENV).to receive(:[]).with('IIIF_S3_FOLDER_PREFIX').and_return(nil) }
+
+      it 'strips the URN prefix and returns the hex' do
+        expect(presenter.send(:external_latest_file_id)).to eq '620cae0e5cf89d9a788cb7d8e31fcbfa78340284'
+      end
+    end
+
+    context 'when digest_ssim is absent' do
+      let(:solr_doc) { SolrDocument.new({}) }
+      let(:digest_value) { nil }
+
+      it 'returns nil' do
+        expect(presenter.send(:external_latest_file_id)).to be_nil
+      end
+    end
+  end
+end
+
 RSpec.describe IiifPrint::IiifManifestPresenterDecorator do
   let(:attributes) do
     { "id" => "abc123",


### PR DESCRIPTION


# Story
Valkyrie uses the MD5 algorithm for  `digest_ssim` which doesn't have the beginning `sha1:` - this reformulation works for either algorithm

# Expected Behavior Before Changes
For applications using Valkyrie, iiif manifests using an `EXTERNAL_IIIF_URL` did not include links to the info.json, because `digest_sha1` raises an error for digests without algorithm prefixes - the manifest could not create the correct link.  

# Expected Behavior After Changes
Applications using Valkyrie with an `EXTERNAL_IIIF_URL` can create valid iiif manifests using Valkyrie-generated digests.

# Notes
This also adds the option to add a prefix to the `external_latest_file_id` - this allows for differentiating S3 paths by environment. 